### PR TITLE
Fix capitalization of git repo URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"keywords": ["css", "selector"],
 	"repository": {
 		"type": "git",
-		"url": "git://github.com/fb55/cssselect.git"
+		"url": "git://github.com/fb55/CSSselect.git"
 	},
 	"dependencies": {
 		"CSSwhat": ">= 0.1"


### PR DESCRIPTION
This PR fixes the capitalization of the git repo URL in package.json.

```
$ git clone git://github.com/fb55/cssselect.git
Cloning into 'cssselect'...
fatal: remote error: 
  Repository not found.

$ git clone git://github.com/fb55/CSSselect.git
Cloning into 'CSSselect'...
remote: Counting objects: 314, done.
remote: Compressing objects: 100% (160/160), done.
remote: Total 314 (delta 151), reused 314 (delta 151)
Receiving objects: 100% (314/314), 102.26 KiB, done.
Resolving deltas: 100% (151/151), done.
```
