### PR TITLE
Lock domutils to 1.2.1 until problems are resolved

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 	},
 	"dependencies": {
 		"CSSwhat": "0.4",
-		"domutils": "1.2"
+		"domutils": "1.2.1"
 	},
 	"devDependencies": {
 		"htmlparser2": "*",


### PR DESCRIPTION
domutils upgrade to 1.2.2 seems to introduce numerous severe issues to the cheerio project. This seems like the quickest fix until figuring out what happened.
