### PR TITLE
Fix unit tests

### DIFF
--- a/test/sizzle/selector.js
+++ b/test/sizzle/selector.js
@@ -1,4 +1,4 @@
-var DomUtils = require("htmlparser2").DomUtils,
+var DomUtils = require("domutils"),
 	helper = require("../tools/helper.js"),
 	CSSselect = helper.CSSselect,
 	assert = require("assert"),


### PR DESCRIPTION
The unit tests rely on a version of the `DomUtils` module that is newer
than the one currently packaged with `HtmlParser2` [1]. This project
already lists a compatible version `DomUtils` as a dependency, so use
the module directly.

[1]
https://github.com/jugglinmike/node-htmlparser/blob/2c568d36d4af04de7754e3194429c238f3793acf/package.json#L25
