### PR TITLE
Remove subsets from input trees

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,18 +2,20 @@
 
 module.exports = CSSselect;
 
-var Pseudos     = require("./lib/pseudos.js"),
-    DomUtils    = require("domutils"),
-    findOne     = DomUtils.findOne,
-    findAll     = DomUtils.findAll,
-    getChildren = DomUtils.getChildren,
-    falseFunc   = require("./lib/basefunctions.js").falseFunc,
-    compile     = require("./lib/compile.js");
+var Pseudos       = require("./lib/pseudos.js"),
+    DomUtils      = require("domutils"),
+    findOne       = DomUtils.findOne,
+    findAll       = DomUtils.findAll,
+    getChildren   = DomUtils.getChildren,
+    removeSubsets = DomUtils.removeSubsets,
+    falseFunc     = require("./lib/basefunctions.js").falseFunc,
+    compile       = require("./lib/compile.js");
 
 function getSelectorFunc(searchFunc){
 	return function select(query, elems, options){
 		if(typeof query !== "function") query = compile(query, options);
 		if(!Array.isArray(elems)) elems = getChildren(elems);
+		else elems = removeSubsets(elems);
 		return searchFunc(query, elems);
 	};
 }

--- a/test/api.js
+++ b/test/api.js
@@ -1,0 +1,31 @@
+var CSSselect = require(".."),
+    htmlparser = require("htmlparser2"),
+    assert = require("assert");
+
+function makeDom(markup) {
+	var handler = new htmlparser.DomHandler(),
+		parser = new htmlparser.Parser(handler);
+	parser.write(markup);
+	parser.done();
+	return handler.dom;
+}
+
+describe("API", function() {
+	describe("removes duplicates", function() {
+		it("between identical trees", function() {
+			var dom = makeDom("<div></div>")[0];
+			var matches = CSSselect("div", [dom, dom]);
+			assert.equal(matches.length, 1, "Removes duplicate matches");
+		});
+		it("between a superset and subset", function() {
+			var dom = makeDom("<div><p></p></div>")[0];
+			var matches = CSSselect("p", [dom, dom.children[0]]);
+			assert.equal(matches.length, 1, "Removes duplicate matches");
+		});
+		it("betweeen a subset and superset", function() {
+			var dom = makeDom("<div><p></p></div>")[0];
+			var matches = CSSselect("p", [dom.children[0], dom]);
+			assert.equal(matches.length, 1, "Removes duplicate matches");
+		});
+	});
+});


### PR DESCRIPTION
As in https://github.com/fb55/DomUtils/pull/4 , I wasn't sure where to place the tests for this functionality. Let me know if there's a better place for them!

This should resolve GitHub issue #12.

Commit message:

> When multiple DOM structures are specified via an array, it is possible
> some structures contain others as subtrees. Since selecting elements
> across these trees may lead to duplicate results, subsets ought to be
> removed prior to selection.
