### PR TITLE
Remove strange character with bad encoding.

### DIFF
--- a/lib/pseudos.js
+++ b/lib/pseudos.js
@@ -329,7 +329,7 @@ module.exports = {
 			return function pseudoArgs(elem){
 				return func(elem, subselect) && next(elem);
 			};
-		} else {
+		} else {
 			throw new SyntaxError("unmatched pseudo-class :" + name);
 		}
 	},


### PR DESCRIPTION
This single character is breaking browserify builds (MatthewMueller/cheerio#268). In a browser it looks like

`} elseÂ {`

And was breaking when attempting to browserify cheerio! As long as this patch makes it to npm, there shouldn't be any need to touch cheerio-select, since it depends on `0.x`.
