### PR TITLE
Add missing `isTag` check in 'nth-last-of-type' pseudo function

### DIFF
--- a/lib/pseudos.js
+++ b/lib/pseudos.js
@@ -127,8 +127,10 @@ var filters = {
 			var siblings = getSiblings(elem);
 
 			for(var pos = 0, i = siblings.length - 1; i >= 0; i--){
-				if(siblings[i] === elem) break;
-				if(getName(siblings[i]) === getName(elem)) pos++;
+				if(isTag(siblings[i])){
+					if(siblings[i] === elem) break;
+					if(getName(siblings[i]) === getName(elem)) pos++;
+				}
 			}
 
 			return func(pos) && next(elem);


### PR DESCRIPTION
Seems like there should be an `isTag` check here, like in `nth-of-type` and other similar functions.

I don't know if the omission would actually cause an issue since the two subsequent `if` checks would fail for text nodes and the like, but might as well be consistent :smile: 
