### PR TITLE
Add failing test to demonstrate regression

### DIFF
--- a/test/api.js
+++ b/test/api.js
@@ -31,6 +31,17 @@ describe("API", function(){
 		//probably more cases should be added here
 	});
 
+	describe("selectAll", function(){
+		it("should query array elements directly when they have no parents", function() {
+			var divs = [dom];
+			assert.deepEqual(CSSselect("div", divs), divs);
+		});
+		it("should query array elements directly when they have parents", function() {
+			var ps = CSSselect("p", [dom]);
+			assert.deepEqual(CSSselect("p", ps), ps);
+		});
+	});
+
 	describe("unsatisfiable and universally valid selectors", function(){
 		it("in :not", function(){
 			var func = CSSselect._compileUnsafe(":not(*)");


### PR DESCRIPTION
Commit 0f0daad251094287a6223ba24467bf073dc2c0fe introduced a breaking
change in this library's functionality: the selection API no longer
matches against elements specified via an array when those elements are
not root nodes.

There were previously no tests asserting this behavior, but the change
should be considered "breaking" for two reasons:

1. it is inconsistent--root nodes may still be queried in this way
2. the project's documentation implies the original behavior:

   > ### `CSSselect(query, elems, options)`
   >
   > Queries `elems`, returns an array containing all matches.
   >
   > - `query` can be either a CSS selector or a function.
   > - `elems` can be either an array of elements, or a single element. If
   >    it is an element, its children will be queried.
   > - `options` is described below.

Add one test that continues to work as expected (selecting from a root
node) and an equivalent test that was made to fail by the commit
mentioned above.