### PR TITLE
pseudos: implement :icontains, case-insensitive version of :contains

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ _As defined by CSS 4 and / or jQuery._
 * Pseudos:
   * `:not`
   * `:contains` *
+  * `:icontains` * (case-insensitive version of `:contains`)
   * `:has` *
   * `:root`
   * `:empty`

--- a/lib/pseudos.js
+++ b/lib/pseudos.js
@@ -52,6 +52,13 @@ var filters = {
 			return next(elem) && getText(elem).indexOf(text) >= 0;
 		};
 	},
+	icontains: function(next, text){
+		var itext = text.toLowerCase();
+		return function icontains(elem){
+			return next(elem) &&
+				getText(elem).toLowerCase().indexOf(itext) >= 0;
+		};
+	},
 
 	//location specific methods
 	"nth-child": function(next, rule){

--- a/test/icontains.js
+++ b/test/icontains.js
@@ -1,0 +1,86 @@
+var CSSselect = require("../"),
+    makeDom = require("htmlparser2").parseDOM,
+    assert = require("assert");
+
+var dom = makeDom("<div><p>In the end, it doesn't really Matter.</p><div>Indeed-that's a delicate matter.</div>");
+
+describe("icontains", function(){
+	describe("ignore case", function(){
+		it("should match full string", function(){
+			var matches = CSSselect.selectAll(":icontains(indeed-that's a delicate matter.)", dom);
+			assert.equal(matches.length, 2);
+			assert.deepEqual(matches, [dom[0], dom[0].children[1]]);
+			matches = CSSselect.selectAll(":icontains(inDeeD-THAT's a DELICATE matteR.)", dom);
+			assert.equal(matches.length, 2);
+			assert.deepEqual(matches, [dom[0], dom[0].children[1]]);
+		});
+
+		it("should match substring", function(){
+			var matches = CSSselect.selectAll(":icontains(indeed)", dom);
+			assert.equal(matches.length, 2);
+			assert.deepEqual(matches, [dom[0], dom[0].children[1]]);
+			matches = CSSselect.selectAll(":icontains(inDeeD)", dom);
+			assert.equal(matches.length, 2);
+			assert.deepEqual(matches, [dom[0], dom[0].children[1]]);
+		});
+
+		it("should match specific element", function(){
+			var matches = CSSselect.selectAll("p:icontains(matter)", dom);
+			assert.equal(matches.length, 1);
+			assert.deepEqual(matches, [dom[0].children[0]]);
+			matches = CSSselect.selectAll("p:icontains(mATter)", dom);
+			assert.equal(matches.length, 1);
+			assert.deepEqual(matches, [dom[0].children[0]]);
+		});
+
+		it("should match multiple elements", function(){
+			var matches = CSSselect.selectAll(":icontains(matter)", dom);
+			assert.equal(matches.length, 3);
+			assert.deepEqual(matches, [dom[0], dom[0].children[0],
+                dom[0].children[1]]);
+			matches = CSSselect.selectAll(":icontains(mATter)", dom);
+			assert.equal(matches.length, 3);
+			assert.deepEqual(matches, [dom[0], dom[0].children[0],
+                dom[0].children[1]]);
+		});
+
+		it("should match empty string", function(){
+            var matches = CSSselect.selectAll(":icontains()", dom);
+			assert.equal(matches.length, 3);
+			assert.deepEqual(matches, [dom[0], dom[0].children[0],
+                dom[0].children[1]]);
+		});
+
+		it("should match quoted string", function(){
+            var matches = CSSselect.selectAll(":icontains('')", dom);
+			assert.equal(matches.length, 3);
+			assert.deepEqual(matches, [dom[0], dom[0].children[0],
+                dom[0].children[1]]);
+            matches = CSSselect.selectAll("p:icontains('matter')", dom);
+			assert.equal(matches.length, 1);
+			assert.deepEqual(matches, [dom[0].children[0]]);
+            matches = CSSselect.selectAll("p:icontains(\"matter\")", dom);
+			assert.equal(matches.length, 1);
+			assert.deepEqual(matches, [dom[0].children[0]]);
+		});
+
+		it("should match whitespace", function(){
+			var matches = CSSselect.selectAll(":icontains( matter)", dom);
+			assert.equal(matches.length, 3);
+			assert.deepEqual(matches, [dom[0], dom[0].children[0],
+                dom[0].children[1]]);
+			matches = CSSselect.selectAll(":icontains( mATter)", dom);
+			assert.equal(matches.length, 3);
+			assert.deepEqual(matches, [dom[0], dom[0].children[0],
+                dom[0].children[1]]);
+		});
+    });
+
+	describe("no matches", function(){
+		it("should not match", function(){
+            var matches = CSSselect.selectAll("p:icontains(indeed)", dom);
+			assert.equal(matches.length, 0);
+		});
+
+    });
+});


### PR DESCRIPTION
As discussed in [issue 33](https://github.com/fb55/css-select/issues/33), with tests.

One of the tests fails and needs a corresponding fix in css-what to strip the quotes of `icontains` data. I have opened a separate [PR](https://github.com/fb55/css-what/pull/15) for that issue.