### PR TITLE
Fix regression, include self while querying array 

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -75,14 +75,16 @@ function compileToken(token, options, context){
 
 	token.forEach(sortRules);
 
+	var isArrayContext = Array.isArray(context);
+
     context = (options && options.context) || context;
 
-    if(context && !Array.isArray(context)) context = [context];
+    if(context && !isArrayContext) context = [context];
 
     absolutize(token, context);
 
 	return token
-		.map(function(rules){ return compileRules(rules, options, context); })
+		.map(function(rules){ return compileRules(rules, options, context, isArrayContext); })
 		.reduce(reduceRules, falseFunc);
 }
 
@@ -90,10 +92,11 @@ function isTraversal(t){
 	return procedure[t.type] < 0;
 }
 
-function compileRules(rules, options, context){
-	return rules.reduce(function(func, rule){
+function compileRules(rules, options, context, isArrayContext){
+	var acceptSelf = (isArrayContext && rules[0].name === "scope" && rules[1].type === "descendant");
+	return rules.reduce(function(func, rule, index){
 		if(func === falseFunc) return func;
-		return Rules[rule.type](func, rule, options, context);
+		return Rules[rule.type](func, rule, options, context, acceptSelf && index === 1);
 	}, options && options.rootFunc || trueFunc);
 }
 

--- a/lib/general.js
+++ b/lib/general.js
@@ -23,8 +23,11 @@ module.exports = {
 	},
 
 	//traversal
-	descendant: function(next){
+	descendant: function(next, rule, options, context, acceptSelf){
 		return function descendant(elem){
+
+			if (acceptSelf && next(elem)) return true;
+
 			var found = false;
 
 			while(!found && (elem = getParent(elem))){

--- a/test/qwery/index.js
+++ b/test/qwery/index.js
@@ -275,7 +275,7 @@ module.exports = {
 
 
 	'exclude self in match': function() {
-		expect(CSSselect('.order-matters', CSSselect('#order-matters', document))).to.have.length(4); //should not include self in element-context queries
+		expect(CSSselect('.order-matters', CSSselect('#order-matters', document)[0])).to.have.length(4); //should not include self in element-context queries
 	},
 
 


### PR DESCRIPTION
This pull request is intended to fix [an issue](https://github.com/cheeriojs/cheerio/issues/728) referenced in Cheerio repository. 
The unit tests used to demonstrate the regression can be found in [this other pull request](https://github.com/fb55/css-select/pull/30).
Basically, if the query's context is a single element, and if the selector matches this one, it should not be added to the results. However, if the context is an array of elements, then these elements can be matched by the query.

The issue was due to `absolutize()` introduced in v1.1.0. This function adds `":scope "` to the selector, and because of the descendant selector `" "`, "root" element to which is applied the query could not be reached. This is fine if the context is a single element, but this is not the expected result if context is an array of elements.
The unit test still worked if the element within the array is the real root of the document because in such a case, the function `absolutize()` did not add `":scope "`.

The simple way to fix this is to add a new token `":scope<selector>"` (without `" "`) to the array for each absolutized element. Of course, this is absolutely not optimal because it creates two tokens which are almost the same, but which have to be executed separately.
The fix I used instead is to make the descendant selector more flexible so it accepts current element (without call `getParent()`) if the context is an array, and if the descendant selector is directly following the first `:scope`. This means others descendant selectors work as usual.

The way I used to specify to a descendant token that it is a special one looks ugly.
I do not have an overall view of css-select, maybe can you make it more clean and simple.

I hope this helps.

