### PR TITLE
Propose an alternative way to solve regression

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -84,9 +84,10 @@ function compileToken(token, options, context){
 
     absolutize(token, context);
 
+    console.log(token);
 	return token
 		.map(function(rules){
-			if (isArrayContext && rules[0].name === "scope" && rules[1].type === "descendant") {
+			if (isArrayContext && rules[0] && rules[1] && rules[0].name === "scope" && rules[1].type === "descendant") {
 				rules[1] = FLEXIBLE_DESCENDANT_TOKEN;
 			}
 			return compileRules(rules, options, context);

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -44,6 +44,7 @@ function includesScopePseudo(t){
 }
 
 var DESCENDANT_TOKEN = {type: "descendant"},
+    FLEXIBLE_DESCENDANT_TOKEN = {type: "flexibleDescendant"},
     SCOPE_TOKEN = {type: "pseudo", name: "scope"},
     PLACEHOLDER_ELEMENT = {},
     getParent = DomUtils.getParent;
@@ -84,7 +85,12 @@ function compileToken(token, options, context){
     absolutize(token, context);
 
 	return token
-		.map(function(rules){ return compileRules(rules, options, context, isArrayContext); })
+		.map(function(rules){
+			if (isArrayContext && rules[0].name === "scope" && rules[1].type === "descendant") {
+				rules[1] = FLEXIBLE_DESCENDANT_TOKEN;
+			}
+			return compileRules(rules, options, context);
+		})
 		.reduce(reduceRules, falseFunc);
 }
 
@@ -92,11 +98,10 @@ function isTraversal(t){
 	return procedure[t.type] < 0;
 }
 
-function compileRules(rules, options, context, isArrayContext){
-	var acceptSelf = (isArrayContext && rules[0].name === "scope" && rules[1].type === "descendant");
+function compileRules(rules, options, context){
 	return rules.reduce(function(func, rule, index){
 		if(func === falseFunc) return func;
-		return Rules[rule.type](func, rule, options, context, acceptSelf && index === 1);
+		return Rules[rule.type](func, rule, options, context);
 	}, options && options.rootFunc || trueFunc);
 }
 

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -99,7 +99,7 @@ function isTraversal(t){
 }
 
 function compileRules(rules, options, context){
-	return rules.reduce(function(func, rule, index){
+	return rules.reduce(function(func, rule){
 		if(func === falseFunc) return func;
 		return Rules[rule.type](func, rule, options, context);
 	}, options && options.rootFunc || trueFunc);

--- a/lib/general.js
+++ b/lib/general.js
@@ -23,12 +23,23 @@ module.exports = {
 	},
 
 	//traversal
-	descendant: function(next, rule, options, context, acceptSelf){
+	descendant: function(next){
 		return function descendant(elem){
 
-			if (acceptSelf && next(elem)) return true;
-
 			var found = false;
+
+			while(!found && (elem = getParent(elem))){
+				found = next(elem);
+			}
+
+			return found;
+		};
+	},
+	flexibleDescendant: function(next){
+		// Include element itself, only used while querying an array
+		return function descendant(elem){
+
+			var found = next(elem);
 
 			while(!found && (elem = getParent(elem))){
 				found = next(elem);


### PR DESCRIPTION
This is a continuation of [my previous pull request](https://github.com/fb55/css-select/pull/37).

I am glad I could you. 
But I said my changes looked ugly, so I tried to improve it.

This commit looks more elegant and efficient than the previous one which added complexity to the code and parameters while trying to make a special descendant selector "flexible".
I think the best is simply to add a new "flexible descendant" selector, so I created a new type of descendant token which accepts element itself. Then, I replace classic descendant within the rule if conditions are fulfilled.