### PR TITLE
prevent errors on valid pseudo selectors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+##########
+# Custom #
+##########
+
+# ~
+#.gitignore
+
+
+#################
+# Project files #
+#################
+
+# modules
+node_modules/
+
+# debug
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ In its default configuration, css-select queries the DOM structure of the [`domh
 
 __Features:__
 
-- Full implementation of CSS3 selectors
+- Full implementation of CSS3 / CSS4 selectors
 - Partial implementation of jQuery/Sizzle extensions
 - Very high test coverage
 - Pretty good performance
@@ -126,7 +126,7 @@ _As defined by CSS 4 and / or jQuery._
   * `:header`, `:button`, `:input`, `:text`, `:checkbox`, `:file`, `:password`, `:reset`, `:radio` etc. *
   * `:matches` *
 
-__*__: Not part of CSS3
+__*__: Not part of the regular CSS specification
 
 ---
 

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -101,7 +101,8 @@ function isTraversal(t){
 function compileRules(rules, options, context){
 	return rules.reduce(function(func, rule){
 		if(func === falseFunc) return func;
-		return Rules[rule.type](func, rule, options, context);
+        var type = (rule.type === "pseudo-element") ? "pseudo" : rule.type;
+		return Rules[type](func, rule, options, context);
 	}, options && options.rootFunc || trueFunc);
 }
 

--- a/lib/pseudos.js
+++ b/lib/pseudos.js
@@ -387,6 +387,10 @@ module.exports = {
     if (!isPseudo(name, true)) {
 			throw new SyntaxError("unmatched pseudo-class :" + name);
 		}
+
+		return function noMatch(){
+			return false;
+		};
 	},
 	filters: filters,
 	pseudos: pseudos

--- a/lib/pseudos.js
+++ b/lib/pseudos.js
@@ -24,7 +24,8 @@ var DomUtils    = require("domutils"),
     checkAttrib = require("./attributes.js").rules.equals,
     BaseFuncs   = require("boolbase"),
     trueFunc    = BaseFuncs.trueFunc,
-    falseFunc   = BaseFuncs.falseFunc;
+    falseFunc   = BaseFuncs.falseFunc,
+		isPseudo    = require("is-pseudo").isPseudo;
 
 //helper methods
 function getFirstElement(elems){
@@ -360,16 +361,13 @@ function verifyArgs(func, name, subselect){
 	}
 }
 
-//FIXME this feels hacky
-var re_CSS3 = /^(?:(?:nth|last|first|only)-(?:child|of-type)|root|empty|(?:en|dis)abled|checked|not)$/;
-
 module.exports = {
 	compile: function(next, data, options, context){
 		var name = data.name,
-			subselect = data.data;
+				subselect = data.data;
 
-		if(options && options.strict && !re_CSS3.test(name)){
-			throw SyntaxError(":" + name + " isn't part of CSS3");
+		if (options && options.strict && !isPseudo(name)) {
+			throw new SyntaxError(":" + name + " isn't part of CSS3");
 		}
 
 		if(typeof filters[name] === "function"){
@@ -384,7 +382,9 @@ module.exports = {
 			return function pseudoArgs(elem){
 				return func(elem, subselect) && next(elem);
 			};
-		} else {
+		}
+
+    if (!isPseudo(name, true)) {
 			throw new SyntaxError("unmatched pseudo-class :" + name);
 		}
 	},

--- a/package.json
+++ b/package.json
@@ -17,9 +17,10 @@
     "lib"
   ],
   "dependencies": {
+    "boolbase": "~1.0.0",
     "css-what": "2.1",
     "domutils": "1.5.1",
-    "boolbase": "~1.0.0",
+    "is-pseudo": "^1.2.0",
     "nth-check": "~1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Although the current version implements quite a few pseudo selectors and claims a `Full implementation of CSS3 selectors`, I just found out that this unfortunately not true for some common cases. So far [a simple regex based check](https://github.com/fb55/css-select/blob/master/lib/pseudos.js#L364) is used to determine valid pseudo selectors. Since this covers only the ones which are properly supported through a function, typical selectors like `:hover`, `:focus` or `::after` keep throwing a SyntaxError. With this update a more extensive lookup is used through [a helper](https://github.com/Autarc/is-pseudo) and even through there are no further matches, at least the call returns without an issue.

In addition I've added a `.gitignore` to avoid accidentally pushing `node_modules` :)