### PR TITLE
Fix #42 by adding siblings elements if needed

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,8 +15,8 @@ var Pseudos       = require("./lib/pseudos.js"),
 
 function getSelectorFunc(searchFunc){
 	return function select(query, elems, options){
-        if(typeof query !== "function") query = compileUnsafe(query, options, elems);
-        if(!Array.isArray(elems)) elems = getChildren(elems);
+		if(typeof query !== "function") query = compileUnsafe(query, options, elems);
+		if(!Array.isArray(elems)) elems = getChildren(elems);
 		else elems = removeSubsets(elems);
 		return searchFunc(query, elems);
 	};

--- a/index.js
+++ b/index.js
@@ -34,7 +34,9 @@ function getNextSiblings(elem){
 
 function appendNextSiblings(elems){
 	// Order matters because jQuery seems to check the children before the siblings
+	if (!Array.isArray(elems)) elems = [elems];
 	var newElems = elems.slice(0);
+
 	for (var i = 0, len = elems.length; i < len; i++) {
 		var nextSiblings = getNextSiblings(newElems[i]);
 		newElems.push.apply(newElems, nextSiblings);

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -33,14 +33,14 @@ function compileUnsafe(selector, options, context){
 }
 
 function includesScopePseudo(t){
-    return t.type === "pseudo" && (
-        t.name === "scope" || (
-            Array.isArray(t.data) &&
-            t.data.some(function(data){
-                return data.some(includesScopePseudo);
-            })
-        )
-    );
+	return t.type === "pseudo" && (
+	    t.name === "scope" || (
+	        Array.isArray(t.data) &&
+	        t.data.some(function(data){
+				return data.some(includesScopePseudo);
+	        })
+	    )
+	);
 }
 
 var DESCENDANT_TOKEN = {type: "descendant"},
@@ -52,37 +52,37 @@ var DESCENDANT_TOKEN = {type: "descendant"},
 //CSS 4 Spec (Draft): 3.3.1. Absolutizing a Scope-relative Selector
 //http://www.w3.org/TR/selectors4/#absolutizing
 function absolutize(token, context){
-    //TODO better check if context is document
-    var hasContext = !!context && !!context.length && context.every(function(e){
-        return e === PLACEHOLDER_ELEMENT || !!getParent(e);
-    });
+	//TODO better check if context is document
+	var hasContext = !!context && !!context.length && context.every(function(e){
+		return e === PLACEHOLDER_ELEMENT || !!getParent(e);
+	});
 
 
-    token.forEach(function(t){
-        if(t.length > 0 && isTraversal(t[0]) && t[0].type !== "descendant"){
-            //don't return in else branch
-        } else if(hasContext && !includesScopePseudo(t)){
-            t.unshift(DESCENDANT_TOKEN);
-        } else {
-            return;
-        }
+	token.forEach(function(t){
+		if(t.length > 0 && isTraversal(t[0]) && t[0].type !== "descendant"){
+			//don't return in else branch
+		} else if(hasContext && !includesScopePseudo(t)){
+			t.unshift(DESCENDANT_TOKEN);
+		} else {
+			return;
+		}
 
-        t.unshift(SCOPE_TOKEN);
-    });
+		t.unshift(SCOPE_TOKEN);
+	});
 }
 
 function compileToken(token, options, context){
-    token = token.filter(function(t){ return t.length > 0; });
+	token = token.filter(function(t){ return t.length > 0; });
 
 	token.forEach(sortRules);
 
 	var isArrayContext = Array.isArray(context);
 
-    context = (options && options.context) || context;
+	context = (options && options.context) || context;
 
-    if(context && !isArrayContext) context = [context];
+	if(context && !isArrayContext) context = [context];
 
-    absolutize(token, context);
+	absolutize(token, context);
 
 	return token
 		.map(function(rules){
@@ -135,9 +135,9 @@ function containsTraversal(t){
 
 filters.not = function(next, token, options, context){
 	var opts = {
-	    	xmlMode: !!(options && options.xmlMode),
-	    	strict: !!(options && options.strict)
-	    };
+	    xmlMode: !!(options && options.xmlMode),
+	    strict: !!(options && options.strict)
+	};
 
 	if(opts.strict){
 		if(token.length > 1 || token.some(containsTraversal)){
@@ -145,7 +145,7 @@ filters.not = function(next, token, options, context){
 		}
 	}
 
-    var func = compileToken(token, opts, context);
+	var func = compileToken(token, opts, context);
 
 	if(func === falseFunc) return next;
 	if(func === trueFunc)  return falseFunc;
@@ -161,8 +161,8 @@ filters.has = function(next, token, options){
 		strict: !!(options && options.strict)
 	};
 
-    //FIXME: Uses an array as a pointer to the current element (side effects)
-    var context = token.some(containsTraversal) ? [PLACEHOLDER_ELEMENT] : null;
+	//FIXME: Uses an array as a pointer to the current element (side effects)
+	var context = token.some(containsTraversal) ? [PLACEHOLDER_ELEMENT] : null;
 
 	var func = compileToken(token, opts, context);
 
@@ -173,15 +173,15 @@ filters.has = function(next, token, options){
 
 	func = wrap(func);
 
-    if(context){
-        return function has(elem){
+	if(context){
+		return function has(elem){
 		return next(elem) && (
-                (context[0] = elem), existsOne(func, getChildren(elem))
-            );
-	};
-    }
+		        (context[0] = elem), existsOne(func, getChildren(elem))
+		    );
+		};
+	}
 
-    return function has(elem){
+	return function has(elem){
 		return next(elem) && existsOne(func, getChildren(elem));
 	};
 };

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -84,14 +84,22 @@ function compileToken(token, options, context){
 
 	absolutize(token, context);
 
-	return token
+	var shouldTestNextSiblings = false;
+
+	var query = token
 		.map(function(rules){
-			if (isArrayContext && rules[0] && rules[1] && rules[0].name === "scope" && rules[1].type === "descendant") {
-				rules[1] = FLEXIBLE_DESCENDANT_TOKEN;
+			if (rules[0] && rules[1] && rules[0].name === "scope") {
+				var ruleType = rules[1].type;
+				if (isArrayContext && ruleType === "descendant") rules[1] = FLEXIBLE_DESCENDANT_TOKEN;
+				else if (ruleType === "adjacent" || ruleType === "sibling") shouldTestNextSiblings = true;
 			}
 			return compileRules(rules, options, context);
 		})
 		.reduce(reduceRules, falseFunc);
+
+	query.shouldTestNextSiblings = shouldTestNextSiblings;
+
+	return query;
 }
 
 function isTraversal(t){

--- a/lib/pseudos.js
+++ b/lib/pseudos.js
@@ -138,30 +138,30 @@ var filters = {
 		};
 	},
 
-    //TODO determine the actual root element
-    root: function(next){
-        return function(elem){
-            return !getParent(elem) && next(elem);
-        };
-    },
+	//TODO determine the actual root element
+	root: function(next){
+		return function(elem){
+			return !getParent(elem) && next(elem);
+		};
+	},
 
-    scope: function(next, rule, options, context){
-        if(!context || context.length === 0){
-            //equivalent to :root
-            return filters.root(next);
-        }
+	scope: function(next, rule, options, context){
+		if(!context || context.length === 0){
+			//equivalent to :root
+			return filters.root(next);
+		}
 
-        if(context.length === 1){
-            //NOTE: can't be unpacked, as :has uses this for side-effects
-            return function(elem){
-                return context[0] === elem && next(elem);
-            };
-        }
+		if(context.length === 1){
+			//NOTE: can't be unpacked, as :has uses this for side-effects
+			return function(elem){
+				return context[0] === elem && next(elem);
+			};
+		}
 
-        return function(elem){
-            return context.indexOf(elem) >= 0 && next(elem);
-        };
-    },
+		return function(elem){
+			return context.indexOf(elem) >= 0 && next(elem);
+		};
+	},
 
 	//jQuery extensions (others follow as pseudos)
 	checkbox: getAttribFunc("type", "checkbox"),
@@ -366,7 +366,7 @@ var re_CSS3 = /^(?:(?:nth|last|first|only)-(?:child|of-type)|root|empty|(?:en|di
 module.exports = {
 	compile: function(next, data, options, context){
 		var name = data.name,
-			subselect = data.data;
+		    subselect = data.data;
 
 		if(options && options.strict && !re_CSS3.test(name)){
 			throw SyntaxError(":" + name + " isn't part of CSS3");

--- a/test/nwmatcher/index.js
+++ b/test/nwmatcher/index.js
@@ -359,7 +359,7 @@ var RUN_BENCHMARKS = false;
 		},
 		"E + F": function(){
 			//Adjacent sibling
-			this.assertEqual(select('div.brothers + div.brothers')[0], getById("uncle"));
+			this.assertEqual(select('div.brothers + div.brothers')[0], getById('uncle'));
 			this.assertEqual(select('div.brothers + div')[0], getById('uncle'));
 			this.assertEqual(select('#level2_1+span')[0], getById('level2_2'));
 			this.assertEqual(select('#level2_1 + span')[0], getById('level2_2'));
@@ -369,6 +369,18 @@ var RUN_BENCHMARKS = false;
 			this.assertEqual(select('#level3_1 + *')[0], getById('level3_2'));
 			this.assertEquivalent(select('#level3_2 + *'), []);
 			this.assertEquivalent(select('#level3_1 + em'), []);
+
+			this.assertEqual(select('+ div.brothers', select('div.brothers'))[0], getById('uncle'));
+			this.assertEqual(select('+ div', select('div.brothers'))[0], getById('uncle'));
+			this.assertEqual(select('+span', select('#level2_1'))[0], getById('level2_2'));
+			this.assertEqual(select('+ span', select('#level2_1'))[0], getById('level2_2'));
+			this.assertEqual(select('+ *', select('#level2_1'))[0], getById('level2_2'));
+			this.assertEquivalent(select('+ span', select('#level2_2')), []);
+			this.assertEqual(select('+ span', select('#level3_1'))[0], getById('level3_2'));
+			this.assertEqual(select('+ *', select('#level3_1'))[0], getById('level3_2'));
+			this.assertEquivalent(select('+ *', select('#level3_2')), []);
+			this.assertEquivalent(select('+ em', select('#level3_1')), []);
+
 			if(RUN_BENCHMARKS){
 				this.wait(function(){
 					this.benchmark(function(){
@@ -385,6 +397,14 @@ var RUN_BENCHMARKS = false;
 			this.assertEquivalent(select('#level1 > span'), getById('level2_1', 'level2_2'));
 			this.assertEquivalent(select('#level2_1 > *'), getById('level3_1', 'level3_2'));
 			this.assertEquivalent(select('div > #nonexistent'), []);
+
+			this.assertEquivalent(select('> a', select('p.first')), getById('link_1', 'link_2'));
+			this.assertEquivalent(select('> div', select('div#grandfather')), getById('father', 'uncle'));
+			this.assertEquivalent(select('>span', select('#level1')), getById('level2_1', 'level2_2'));
+			this.assertEquivalent(select('> span', select('#level1')), getById('level2_1', 'level2_2'));
+			this.assertEquivalent(select('> *', select('#level2_1')), getById('level3_1', 'level3_2'));
+			this.assertEquivalent(select('> #nonexistent', select('div')), []);
+
 			if(RUN_BENCHMARKS){
 				this.wait(function(){
 					this.benchmark(function(){
@@ -405,6 +425,18 @@ var RUN_BENCHMARKS = false;
 			this.assertEquivalent(select('#level2_1 ~ *'), getById('level2_2', 'level2_3'));
 			this.assertEqual(select('#level3_1 ~ #level3_2')[0], getById('level3_2'));
 			this.assertEqual(select('span ~ #level3_2')[0], getById('level3_2'));
+
+			this.assertEqual(select('~ ul', select('h1'))[0], getById('list'));
+			this.assertEquivalent(select('~ span', select('#level2_2')), []);
+			this.assertEquivalent(select('~ *', select('#level3_2')), []);
+			this.assertEquivalent(select('~ em', select('#level3_1')), []);
+			this.assertEquivalent(select('~ #level3_2', select('div')), []);
+			this.assertEquivalent(select('~ #level2_3', select('div')), []);
+			this.assertEqual(select('~ span', select('#level2_1'))[0], getById('level2_2'));
+			this.assertEquivalent(select('~ *', select('#level2_1')), getById('level2_2', 'level2_3'));
+			this.assertEqual(select('~ #level3_2', select('#level3_1'))[0], getById('level3_2'));
+			this.assertEqual(select('~ #level3_2', select('span'))[0], getById('level3_2'));
+
 			if(RUN_BENCHMARKS){
 				this.wait(function(){
 					this.benchmark(function(){

--- a/test/qwery/index.js
+++ b/test/qwery/index.js
@@ -249,14 +249,12 @@ module.exports = {
 
 'element-context queries': {
 
-/*
 	'relationship-first queries': function() {
 		expect(CSSselect('> .direct-descend', CSSselect('#direct-descend', document))).to.have.length(2); //found two direct descendents using > first
 		expect(CSSselect('~ .sibling-selector', CSSselect('#sibling-selector', document))).to.have.length(2); //found two siblings with ~ first
 		expect(CSSselect('+ .sibling-selector', CSSselect('#sibling-selector', document))).to.have.length(1); //found one sibling with + first
 		expect(CSSselect('> .tokens a', CSSselect('.idless', document)[0])).to.have.length(1); //found one sibling from a root with no id
 	},
-*/
 
 	// should be able to query on an element that hasn't been inserted into the dom
 	'detached fragments': function() {

--- a/test/sizzle/selector.js
+++ b/test/sizzle/selector.js
@@ -457,13 +457,13 @@ test("child and adjacent", function() {
 
 	siblingFirst = document.getElementById("siblingfirst");
 
-	//deepEqual( Sizzle("~ em", siblingFirst), q("siblingnext", "siblingthird"), "Element Preceded By with a context." );
-	//deepEqual( Sizzle("+ em", siblingFirst), q("siblingnext"), "Element Directly Preceded By with a context." );
+	deepEqual( Sizzle("~ em", siblingFirst), q("siblingnext", "siblingthird"), "Element Preceded By with a context." );
+	deepEqual( Sizzle("+ em", siblingFirst), q("siblingnext"), "Element Directly Preceded By with a context." );
 	//deepEqual( Sizzle("~ em:first", siblingFirst), q("siblingnext"), "Element Preceded By positional with a context." );
 
 	en = document.getElementById("en");
-	//deepEqual( Sizzle("+ p, a", en), q("yahoo", "sap"), "Compound selector with context, beginning with sibling test." );
-	//deepEqual( Sizzle("a, + p", en), q("yahoo", "sap"), "Compound selector with context, containing sibling test." );
+	deepEqual( Sizzle("+ p, a", en), q("yahoo", "sap"), "Compound selector with context, beginning with sibling test." );
+	deepEqual( Sizzle("a, + p", en), q("yahoo", "sap"), "Compound selector with context, containing sibling test." );
 
 	t( "Multiple combinators selects all levels", "#siblingTest em *", ["siblingchild", "siblinggrandchild", "siblinggreatgrandchild"] );
 	t( "Multiple combinators selects all levels", "#siblingTest > em *", ["siblingchild", "siblinggrandchild", "siblinggreatgrandchild"] );


### PR DESCRIPTION
So, partly because css-select is "right-to-left execution", it was not able to properly find siblings elements when the selector was starting with `+` (or `~`) and when the reference element was passed to the context.
Indeed, the query function is applied to each elements and children contained in the context object, but siblings and adjacent are not included, so these elements could not be tested, and could not be returned by the `select` function.

The way to solve this is to extend the `elems` array with the next siblings of each of its elements. Thanks to the tokens `:scope` which are prepended during the compilation, the unwanted elements from siblings's children will not be queried. Of course, we do not want to do this for each query, because this may be very slow. So, we have to check for the special case (selector starting with `+` or `~`), and add siblings only if this case is detected.

To check if the searched elements need to include the siblings, I decided to add some kind of flag `shouldTestNextSiblings` as a property of the `query` function. I chose this approach for several reasons:
* It avoid having to loop trough the tokens once again, while it is already done during the compilation
* It preserves all functions signatures and do not modify any API
* It makes the information readable from "the outdoor", for example by someone using the `compile` function
* It opens the door to others kinds of properties, like `minDepth` for issue #5 

Then, after the query compilation, it is possible to check for the presence of this flag, and add next siblings elements if it is set to `true`.

Also, note that I thought to add two flags, each one for `+` and `~`, and possibly only append next adjacent rather than all the next siblings. I did not select this option because it worked anyway, and it reduces the numbers of operations performed for all common queries with no special case.

===

I need some code review about what you think to this pull request, @fb55.

I duplicated the tests made within the `nwmatcher` folder, but it was maybe not the best option. Also, it is perhaps useful to add others tests, rather than just use the duplicated ones.

I made the changes in my Cheerio repo and all tests still passed (and the bug https://github.com/cheeriojs/cheerio/issues/867 seems fixed).

However, the prepended `:scope` token and the `root` special case still trouble me. It may have problem in these cases because I do not fully understand eveything yet.
Moreover, at first, my fix looked like this: `if (query.shouldTestNextSiblings) elems = appendNextSiblings(elems);` but while all tests passed for css-select, it fails for Cheerio. This is why I changed it to `appendNextSiblings((options && options.context) || elems)` but I am not comfortable with this, I am not sure this is ok.