### PR TITLE
Allow adapter to be passed in options

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ a CSS selector compiler/engine
 css-select turns CSS selectors into functions that tests if elements match them. When searching for elements, testing is executed "from the top", similar to how browsers execute CSS selectors.
 
 In its default configuration, css-select queries the DOM structure of the [`domhandler`](https://github.com/fb55/domhandler) module (also known as htmlparser2 DOM).
+It uses [`domutils`](https://github.com/fb55/domutils) as its default adapter over the DOM structure. See Options below for details on querying alternative DOM structures.
 
 __Features:__
 
@@ -86,6 +87,73 @@ Arguments are the same as for `CSSselect(query, elems)`. Only returns the first 
 - `xmlMode`: When enabled, tag names will be case-sensitive. Default: `false`.
 - `strict`: Limits the module to only use CSS3 selectors. Default: `false`.
 - `rootFunc`: The last function in the stack, will be called with the last element that's looked at. Should return `true`.
+- `adapter`: The adapter to use when interacting with the backing DOM structure. By default it uses [`domutils`](https://github.com/fb55/domutils).
+
+#### Custom Adapters
+
+A custom adapter must implement the following functions:
+
+```
+isTag, existsOne, getAttributeValue, getChildren, getName, getParent,
+getSiblings, getText, hasAttrib, removeSubsets, findAll
+```
+
+The method signature notation used below should be fairly intuitive - if not,
+see the [`rtype`](https://github.com/ericelliott/rtype) or
+[`TypeScript`](https://www.typescriptlang.org/) docs, as it is very similar to
+both of those. You may also want to look at
+[`domutils`](https://github.com/fb55/domutils) to see the default
+implementation.
+
+```ts
+{
+  // is the node a tag?
+  isTag: ( node:Node ) => isTag:Boolean,
+
+  // does at least one of passed element nodes pass the test predicate?
+  existsOne: ( test:Predicate, elems:[ElementNode] ) => existsOne:Boolean,
+
+  // get the attribute value
+  getAttributeValue: ( elem:ElementNode, name:String ) => value:String,
+
+  // get the node's children
+  getChildren: ( node:Node ) => children:[Node],
+
+  // get the name of the tag
+  getName: ( elem:ElementNode ) => tagName:String,
+
+  // get the parent of the node
+  getParent: ( node:Node ) => parentNode:Node,
+
+  /*
+    get the siblings of the node. Note that unlike jQuery's `siblings` method,
+    this is expected to include the current node as well
+  */
+  getSiblings: ( node:Node ) => siblings:[Node],
+
+  // get the text content of the node, and its children if it has any
+  getText: ( node:Node ) => text:String,
+
+  // does the element have the named attribute?
+  hasAttrib: ( elem:ElementNode, name:String ) => hasAttrib:Boolean,
+
+  // takes an array of nodes, and removes any duplicates, as well as any nodes
+  // whose ancestors are also in the array
+  removeSubsets: ( nodes:[Node] ) => unique:[Node],
+
+  // finds all of the element nodes in the array that match the test predicate,
+  // as well as any of their children that match it
+  findAll: ( test:Predicate, nodes:[Node] ) => elems:[ElementNode],
+
+  /*
+    The adapter can also optionally include an equals method, if your DOM
+    structure needs a custom equality test to compare two objects which refer
+    to the same underlying node. If not provided, `css-select` will fall back to
+    `a === b`.
+  */
+  equals: ( a:Node, b:Node ) => Boolean
+}
+```
 
 ## Supported selectors
 

--- a/browser-adapter.js
+++ b/browser-adapter.js
@@ -52,8 +52,9 @@ var adapter = {
 	},
 	getChildren: getChildren,
 	getParent: getParent,
-	getAttributeValue: function(elem, name){
-		return elem.attributes[name].value;
+	getAttributeValue: function(elem, name){		
+		if( elem.attributes && elem.attributes[name])
+			return elem.attributes[name].value;
 	},
 	hasAttrib: function(elem, name){
 		return name in elem.attributes;

--- a/index.js
+++ b/index.js
@@ -5,8 +5,8 @@ module.exports = CSSselect;
 var DomUtils       = require("domutils"),
     falseFunc      = require("boolbase").falseFunc,
     compileFactory = require("./lib/compile.js"),
-		browserAdapter = require("./browser-adapter"),
-		defaultCompile = compileFactory(DomUtils);
+    browserAdapter = require("./browser-adapter"),
+    defaultCompile = compileFactory(DomUtils);
 
 function getAdapter(options){
 	if( options && options.adapter ) return options.adapter;

--- a/index.js
+++ b/index.js
@@ -2,57 +2,78 @@
 
 module.exports = CSSselect;
 
-var Pseudos       = require("./lib/pseudos.js"),
-    DomUtils      = require("domutils"),
-    findOne       = DomUtils.findOne,
-    findAll       = DomUtils.findAll,
-    getChildren   = DomUtils.getChildren,
-    getSiblings   = DomUtils.getSiblings,
-    removeSubsets = DomUtils.removeSubsets,
-    falseFunc     = require("boolbase").falseFunc,
-    compile       = require("./lib/compile.js"),
-    compileUnsafe = compile.compileUnsafe,
-    compileToken  = compile.compileToken;
+var DomUtils       = require("domutils"),
+    falseFunc      = require("boolbase").falseFunc,
+    compileFactory = require("./lib/compile.js"),
+		browserAdapter = require("./browser-adapter"),
+		defaultCompile = compileFactory(DomUtils);
+
+function getAdapter(options){
+	if( options && options.adapter ) return options.adapter;
+
+	return DomUtils;
+}
 
 function getSelectorFunc(searchFunc){
 	return function select(query, elems, options){
+		var adapter = getAdapter( options ),
+				compile,
+				compileUnsafe;
+
+		if( adapter === DomUtils ){
+			compile = defaultCompile;
+		} else {
+			compile = compileFactory( adapter );
+		}
+
+		compileUnsafe = compile.compileUnsafe;
+
 		if(typeof query !== "function") query = compileUnsafe(query, options, elems);
-		if(query.shouldTestNextSiblings) elems = appendNextSiblings((options && options.context) || elems);
-		if(!Array.isArray(elems)) elems = getChildren(elems);
-		else elems = removeSubsets(elems);
-		return searchFunc(query, elems);
+		if(query.shouldTestNextSiblings) elems = appendNextSiblings((options && options.context) || elems, adapter);
+		if(!Array.isArray(elems)) elems = adapter.getChildren(elems);
+		else elems = adapter.removeSubsets(elems);
+		return searchFunc(query, elems, adapter);
 	};
 }
 
-function getNextSiblings(elem){
-	var siblings = getSiblings(elem);
+function getNextSiblings(elem, adapter){
+	var siblings = adapter.getSiblings(elem);
 	if(!Array.isArray(siblings)) return [];
 	siblings = siblings.slice(0);
 	while(siblings.shift() !== elem);
 	return siblings;
 }
 
-function appendNextSiblings(elems){
+function appendNextSiblings(elems, adapter){
 	// Order matters because jQuery seems to check the children before the siblings
 	if(!Array.isArray(elems)) elems = [elems];
 	var newElems = elems.slice(0);
 
 	for(var i = 0, len = elems.length; i < len; i++) {
-		var nextSiblings = getNextSiblings(newElems[i]);
+		var nextSiblings = getNextSiblings(newElems[i], adapter);
 		newElems.push.apply(newElems, nextSiblings);
 	}
 	return newElems;
 }
 
-var selectAll = getSelectorFunc(function selectAll(query, elems){
-	return (query === falseFunc || !elems || elems.length === 0) ? [] : findAll(query, elems);
+var selectAll = getSelectorFunc(function selectAll(query, elems, adapter){
+	return (query === falseFunc || !elems || elems.length === 0) ? [] : adapter.findAll(query, elems);
 });
 
-var selectOne = getSelectorFunc(function selectOne(query, elems){
-	return (query === falseFunc || !elems || elems.length === 0) ? null : findOne(query, elems);
+var selectOne = getSelectorFunc(function selectOne(query, elems, adapter){
+	return (query === falseFunc || !elems || elems.length === 0) ? null : adapter.findOne(query, elems);
 });
 
 function is(elem, query, options){
+	var adapter = getAdapter( options ),
+			compile;
+
+	if( adapter === DomUtils ){
+		compile = defaultCompile;
+	} else {
+		compile = compileFactory( adapter );
+	}
+
 	return (typeof query === "function" ? query : compile(query, options))(elem);
 }
 
@@ -63,19 +84,24 @@ function CSSselect(query, elems, options){
 	return selectAll(query, elems, options);
 }
 
-CSSselect.compile = compile;
-CSSselect.filters = Pseudos.filters;
-CSSselect.pseudos = Pseudos.pseudos;
+CSSselect.compile = defaultCompile;
+CSSselect.filters = defaultCompile.Pseudos.filters;
+CSSselect.pseudos = defaultCompile.Pseudos.pseudos;
 
 CSSselect.selectAll = selectAll;
 CSSselect.selectOne = selectOne;
 
 CSSselect.is = is;
 
+CSSselect.adapters = {
+	default: DomUtils,
+	browser: browserAdapter
+};
+
 //legacy methods (might be removed)
-CSSselect.parse = compile;
+CSSselect.parse = defaultCompile;
 CSSselect.iterate = selectAll;
 
 //hooks
-CSSselect._compileUnsafe = compileUnsafe;
-CSSselect._compileToken = compileToken;
+CSSselect._compileUnsafe = defaultCompile.compileUnsafe;
+CSSselect._compileToken = defaultCompile.compileToken;

--- a/lib/attributes.js
+++ b/lib/attributes.js
@@ -1,181 +1,186 @@
-var DomUtils  = require("domutils"),
-    hasAttrib = DomUtils.hasAttrib,
-    getAttributeValue = DomUtils.getAttributeValue,
-    falseFunc = require("boolbase").falseFunc;
+var falseFunc = require("boolbase").falseFunc;
 
 //https://github.com/slevithan/XRegExp/blob/master/src/xregexp.js#L469
 var reChars = /[-[\]{}()*+?.,\\^$|#\s]/g;
 
-/*
-	attribute selectors
-*/
+function attributeRulesFactory(adapter){
+	/*
+		attribute selectors
+	*/
+	var attributeRules = {
+		__proto__: null,
+		equals: function(next, data){
+			var name  = data.name,
+					value = data.value;
 
-var attributeRules = {
-	__proto__: null,
-	equals: function(next, data){
-		var name  = data.name,
-		    value = data.value;
+			if(data.ignoreCase){
+				value = value.toLowerCase();
 
-		if(data.ignoreCase){
-			value = value.toLowerCase();
+				return function equalsIC(elem){
+					var attr = adapter.getAttributeValue(elem, name);
+					return attr != null && attr.toLowerCase() === value && next(elem);
+				};
+			}
 
-			return function equalsIC(elem){
-				var attr = getAttributeValue(elem, name);
-				return attr != null && attr.toLowerCase() === value && next(elem);
+			return function equals(elem){
+				return adapter.getAttributeValue(elem, name) === value && next(elem);
 			};
-		}
+		},
+		hyphen: function(next, data){
+			var name  = data.name,
+					value = data.value,
+					len = value.length;
 
-		return function equals(elem){
-			return getAttributeValue(elem, name) === value && next(elem);
-		};
-	},
-	hyphen: function(next, data){
-		var name  = data.name,
-		    value = data.value,
-		    len = value.length;
+			if(data.ignoreCase){
+				value = value.toLowerCase();
 
-		if(data.ignoreCase){
-			value = value.toLowerCase();
+				return function hyphenIC(elem){
+					var attr = adapter.getAttributeValue(elem, name);
+					return attr != null &&
+							(attr.length === len || attr.charAt(len) === "-") &&
+							attr.substr(0, len).toLowerCase() === value &&
+							next(elem);
+				};
+			}
 
-			return function hyphenIC(elem){
-				var attr = getAttributeValue(elem, name);
+			return function hyphen(elem){
+				var attr = adapter.getAttributeValue(elem, name);
 				return attr != null &&
+						attr.substr(0, len) === value &&
 						(attr.length === len || attr.charAt(len) === "-") &&
-						attr.substr(0, len).toLowerCase() === value &&
 						next(elem);
 			};
-		}
+		},
+		element: function(next, data){
+			var name = data.name,
+					value = data.value;
 
-		return function hyphen(elem){
-			var attr = getAttributeValue(elem, name);
-			return attr != null &&
-					attr.substr(0, len) === value &&
-					(attr.length === len || attr.charAt(len) === "-") &&
-					next(elem);
-		};
-	},
-	element: function(next, data){
-		var name = data.name,
-		    value = data.value;
+			if(/\s/.test(value)){
+				return falseFunc;
+			}
 
-		if(/\s/.test(value)){
-			return falseFunc;
-		}
+			value = value.replace(reChars, "\\$&");
 
-		value = value.replace(reChars, "\\$&");
+			var pattern = "(?:^|\\s)" + value + "(?:$|\\s)",
+					flags = data.ignoreCase ? "i" : "",
+					regex = new RegExp(pattern, flags);
 
-		var pattern = "(?:^|\\s)" + value + "(?:$|\\s)",
-		    flags = data.ignoreCase ? "i" : "",
-		    regex = new RegExp(pattern, flags);
-
-		return function element(elem){
-			var attr = getAttributeValue(elem, name);
-			return attr != null && regex.test(attr) && next(elem);
-		};
-	},
-	exists: function(next, data){
-		var name = data.name;
-		return function exists(elem){
-			return hasAttrib(elem, name) && next(elem);
-		};
-	},
-	start: function(next, data){
-		var name  = data.name,
-		    value = data.value,
-		    len = value.length;
-
-		if(len === 0){
-			return falseFunc;
-		}
-
-		if(data.ignoreCase){
-			value = value.toLowerCase();
-
-			return function startIC(elem){
-				var attr = getAttributeValue(elem, name);
-				return attr != null && attr.substr(0, len).toLowerCase() === value && next(elem);
-			};
-		}
-
-		return function start(elem){
-			var attr = getAttributeValue(elem, name);
-			return attr != null && attr.substr(0, len) === value && next(elem);
-		};
-	},
-	end: function(next, data){
-		var name  = data.name,
-		    value = data.value,
-		    len   = -value.length;
-
-		if(len === 0){
-			return falseFunc;
-		}
-
-		if(data.ignoreCase){
-			value = value.toLowerCase();
-
-			return function endIC(elem){
-				var attr = getAttributeValue(elem, name);
-				return attr != null && attr.substr(len).toLowerCase() === value && next(elem);
-			};
-		}
-
-		return function end(elem){
-			var attr = getAttributeValue(elem, name);
-			return attr != null && attr.substr(len) === value && next(elem);
-		};
-	},
-	any: function(next, data){
-		var name  = data.name,
-		    value = data.value;
-
-		if(value === ""){
-			return falseFunc;
-		}
-
-		if(data.ignoreCase){
-			var regex = new RegExp(value.replace(reChars, "\\$&"), "i");
-
-			return function anyIC(elem){
-				var attr = getAttributeValue(elem, name);
+			return function element(elem){
+				var attr = adapter.getAttributeValue(elem, name);
 				return attr != null && regex.test(attr) && next(elem);
 			};
-		}
-
-		return function any(elem){
-			var attr = getAttributeValue(elem, name);
-			return attr != null && attr.indexOf(value) >= 0 && next(elem);
-		};
-	},
-	not: function(next, data){
-		var name  = data.name,
-		    value = data.value;
-
-		if(value === ""){
-			return function notEmpty(elem){
-				return !!getAttributeValue(elem, name) && next(elem);
+		},
+		exists: function(next, data){
+			var name = data.name;
+			return function exists(elem){
+				return adapter.hasAttrib(elem, name) && next(elem);
 			};
-		} else if(data.ignoreCase){
-			value = value.toLowerCase();
+		},
+		start: function(next, data){
+			var name  = data.name,
+					value = data.value,
+					len = value.length;
 
-			return function notIC(elem){
-				var attr = getAttributeValue(elem, name);
-				return attr != null && attr.toLowerCase() !== value && next(elem);
+			if(len === 0){
+				return falseFunc;
+			}
+
+			if(data.ignoreCase){
+				value = value.toLowerCase();
+
+				return function startIC(elem){
+					var attr = adapter.getAttributeValue(elem, name);
+					return attr != null && attr.substr(0, len).toLowerCase() === value && next(elem);
+				};
+			}
+
+			return function start(elem){
+				var attr = adapter.getAttributeValue(elem, name);
+				return attr != null && attr.substr(0, len) === value && next(elem);
+			};
+		},
+		end: function(next, data){
+			var name  = data.name,
+					value = data.value,
+					len   = -value.length;
+
+			if(len === 0){
+				return falseFunc;
+			}
+
+			if(data.ignoreCase){
+				value = value.toLowerCase();
+
+				return function endIC(elem){
+					var attr = adapter.getAttributeValue(elem, name);
+					return attr != null && attr.substr(len).toLowerCase() === value && next(elem);
+				};
+			}
+
+			return function end(elem){
+				var attr = adapter.getAttributeValue(elem, name);
+				return attr != null && attr.substr(len) === value && next(elem);
+			};
+		},
+		any: function(next, data){
+			var name  = data.name,
+					value = data.value;
+
+			if(value === ""){
+				return falseFunc;
+			}
+
+			if(data.ignoreCase){
+				var regex = new RegExp(value.replace(reChars, "\\$&"), "i");
+
+				return function anyIC(elem){
+					var attr = adapter.getAttributeValue(elem, name);
+					return attr != null && regex.test(attr) && next(elem);
+				};
+			}
+
+			return function any(elem){
+				var attr = adapter.getAttributeValue(elem, name);
+				return attr != null && attr.indexOf(value) >= 0 && next(elem);
+			};
+		},
+		not: function(next, data){
+			var name  = data.name,
+					value = data.value;
+
+			if(value === ""){
+				return function notEmpty(elem){
+					return !!adapter.getAttributeValue(elem, name) && next(elem);
+				};
+			} else if(data.ignoreCase){
+				value = value.toLowerCase();
+
+				return function notIC(elem){
+					var attr = adapter.getAttributeValue(elem, name);
+					return attr != null && attr.toLowerCase() !== value && next(elem);
+				};
+			}
+
+			return function not(elem){
+				return adapter.getAttributeValue(elem, name) !== value && next(elem);
 			};
 		}
+	};
+	return attributeRules;
+}
 
-		return function not(elem){
-			return getAttributeValue(elem, name) !== value && next(elem);
-		};
-	}
-};
+function factory(adapter){
+	var attributeRules = attributeRulesFactory(adapter);
 
-module.exports = {
-	compile: function(next, data, options){
-		if(options && options.strict && (
-			data.ignoreCase || data.action === "not"
-		)) throw new Error("Unsupported attribute selector");
-		return attributeRules[data.action](next, data);
-	},
-	rules: attributeRules
-};
+	return {
+		compile: function(next, data, options){
+			if(options && options.strict && (
+				data.ignoreCase || data.action === "not"
+			)) throw new Error("Unsupported attribute selector");
+			return attributeRules[data.action](next, data);
+		},
+		rules: attributeRules
+	};
+}
+
+module.exports = factory;

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -6,10 +6,10 @@ module.exports = compileFactory;
 
 var parse          = require("css-what"),
     BaseFuncs      = require("boolbase"),
-		sortRules      = require("./sort.js"),
-		procedure      = require("./procedure.json"),
-		rulesFactory   = require("./general.js"),
-		pseudosFactory = require("./pseudos.js"),
+    sortRules      = require("./sort.js"),
+    procedure      = require("./procedure.json"),
+    rulesFactory   = require("./general.js"),
+    pseudosFactory = require("./pseudos.js"),
     trueFunc       = BaseFuncs.trueFunc,
     falseFunc      = BaseFuncs.falseFunc;
 

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -2,205 +2,206 @@
 	compiles a selector to an executable function
 */
 
-module.exports = compile;
-module.exports.compileUnsafe = compileUnsafe;
-module.exports.compileToken = compileToken;
+module.exports = compileFactory;
 
-var parse       = require("css-what"),
-    DomUtils    = require("domutils"),
-    isTag       = DomUtils.isTag,
-    Rules       = require("./general.js"),
-    sortRules   = require("./sort.js"),
-    BaseFuncs   = require("boolbase"),
-    trueFunc    = BaseFuncs.trueFunc,
-    falseFunc   = BaseFuncs.falseFunc,
-    procedure   = require("./procedure.json");
+var parse          = require("css-what"),
+    BaseFuncs      = require("boolbase"),
+		sortRules      = require("./sort.js"),
+		procedure      = require("./procedure.json"),
+		rulesFactory   = require("./general.js"),
+		pseudosFactory = require("./pseudos.js"),
+    trueFunc       = BaseFuncs.trueFunc,
+    falseFunc      = BaseFuncs.falseFunc;
 
-function compile(selector, options, context){
-	var next = compileUnsafe(selector, options, context);
-	return wrap(next);
-}
+function compileFactory(adapter){
+	var Pseudos     = pseudosFactory(adapter),
+			filters     = Pseudos.filters,
+			Rules 			= rulesFactory(adapter, Pseudos);
 
-function wrap(next){
-	return function base(elem){
-		return isTag(elem) && next(elem);
-	};
-}
+	function compile(selector, options, context){
+		var next = compileUnsafe(selector, options, context);
+		return wrap(next);
+	}
 
-function compileUnsafe(selector, options, context){
-	var token = parse(selector, options);
-	return compileToken(token, options, context);
-}
+	function wrap(next){
+		return function base(elem){
+			return adapter.isTag(elem) && next(elem);
+		};
+	}
 
-function includesScopePseudo(t){
-	return t.type === "pseudo" && (
-		t.name === "scope" || (
-			Array.isArray(t.data) &&
-			t.data.some(function(data){
-				return data.some(includesScopePseudo);
-			})
-		)
-	);
-}
+	function compileUnsafe(selector, options, context){
+		var token = parse(selector, options);
+		return compileToken(token, options, context);
+	}
 
-var DESCENDANT_TOKEN = {type: "descendant"},
-    FLEXIBLE_DESCENDANT_TOKEN = {type: "_flexibleDescendant"},
-    SCOPE_TOKEN = {type: "pseudo", name: "scope"},
-    PLACEHOLDER_ELEMENT = {},
-    getParent = DomUtils.getParent;
+	function includesScopePseudo(t){
+		return t.type === "pseudo" && (
+			t.name === "scope" || (
+				Array.isArray(t.data) &&
+				t.data.some(function(data){
+					return data.some(includesScopePseudo);
+				})
+			)
+		);
+	}
 
-//CSS 4 Spec (Draft): 3.3.1. Absolutizing a Scope-relative Selector
-//http://www.w3.org/TR/selectors4/#absolutizing
-function absolutize(token, context){
-	//TODO better check if context is document
-	var hasContext = !!context && !!context.length && context.every(function(e){
-		return e === PLACEHOLDER_ELEMENT || !!getParent(e);
-	});
+	var DESCENDANT_TOKEN = {type: "descendant"},
+			FLEXIBLE_DESCENDANT_TOKEN = {type: "_flexibleDescendant"},
+			SCOPE_TOKEN = {type: "pseudo", name: "scope"},
+			PLACEHOLDER_ELEMENT = {};
+
+	//CSS 4 Spec (Draft): 3.3.1. Absolutizing a Scope-relative Selector
+	//http://www.w3.org/TR/selectors4/#absolutizing
+	function absolutize(token, context){
+		//TODO better check if context is document
+		var hasContext = !!context && !!context.length && context.every(function(e){
+			return e === PLACEHOLDER_ELEMENT || !!adapter.getParent(e);
+		});
 
 
-	token.forEach(function(t){
-		if(t.length > 0 && isTraversal(t[0]) && t[0].type !== "descendant"){
-			//don't return in else branch
-		} else if(hasContext && !includesScopePseudo(t)){
-			t.unshift(DESCENDANT_TOKEN);
-		} else {
-			return;
-		}
-
-		t.unshift(SCOPE_TOKEN);
-	});
-}
-
-function compileToken(token, options, context){
-	token = token.filter(function(t){ return t.length > 0; });
-
-	token.forEach(sortRules);
-
-	var isArrayContext = Array.isArray(context);
-
-	context = (options && options.context) || context;
-
-	if(context && !isArrayContext) context = [context];
-
-	absolutize(token, context);
-
-	var shouldTestNextSiblings = false;
-
-	var query = token
-		.map(function(rules){
-			if(rules[0] && rules[1] && rules[0].name === "scope") {
-				var ruleType = rules[1].type;
-				if(isArrayContext && ruleType === "descendant") rules[1] = FLEXIBLE_DESCENDANT_TOKEN;
-				else if(ruleType === "adjacent" || ruleType === "sibling") shouldTestNextSiblings = true;
+		token.forEach(function(t){
+			if(t.length > 0 && isTraversal(t[0]) && t[0].type !== "descendant"){
+				//don't return in else branch
+			} else if(hasContext && !includesScopePseudo(t)){
+				t.unshift(DESCENDANT_TOKEN);
+			} else {
+				return;
 			}
-			return compileRules(rules, options, context);
-		})
-		.reduce(reduceRules, falseFunc);
 
-	query.shouldTestNextSiblings = shouldTestNextSiblings;
-
-	return query;
-}
-
-function isTraversal(t){
-	return procedure[t.type] < 0;
-}
-
-function compileRules(rules, options, context){
-	return rules.reduce(function(func, rule){
-		if(func === falseFunc) return func;
-		return Rules[rule.type](func, rule, options, context);
-	}, options && options.rootFunc || trueFunc);
-}
-
-function reduceRules(a, b){
-	if(b === falseFunc || a === trueFunc){
-		return a;
-	}
-	if(a === falseFunc || b === trueFunc){
-		return b;
+			t.unshift(SCOPE_TOKEN);
+		});
 	}
 
-	return function combine(elem){
-		return a(elem) || b(elem);
-	};
-}
+	function compileToken(token, options, context){
+		token = token.filter(function(t){ return t.length > 0; });
 
-//:not, :has and :matches have to compile selectors
-//doing this in lib/pseudos.js would lead to circular dependencies,
-//so we add them here
+		token.forEach(sortRules);
 
-var Pseudos     = require("./pseudos.js"),
-    filters     = Pseudos.filters,
-    existsOne   = DomUtils.existsOne,
-    getChildren = DomUtils.getChildren;
+		var isArrayContext = Array.isArray(context);
 
+		context = (options && options.context) || context;
 
-function containsTraversal(t){
-	return t.some(isTraversal);
-}
+		if(context && !isArrayContext) context = [context];
 
-filters.not = function(next, token, options, context){
-	var opts = {
-		xmlMode: !!(options && options.xmlMode),
-		strict: !!(options && options.strict)
-	};
+		absolutize(token, context);
 
-	if(opts.strict){
-		if(token.length > 1 || token.some(containsTraversal)){
-			throw new Error("complex selectors in :not aren't allowed in strict mode");
+		var shouldTestNextSiblings = false;
+
+		var query = token
+			.map(function(rules){
+				if(rules[0] && rules[1] && rules[0].name === "scope") {
+					var ruleType = rules[1].type;
+					if(isArrayContext && ruleType === "descendant") rules[1] = FLEXIBLE_DESCENDANT_TOKEN;
+					else if(ruleType === "adjacent" || ruleType === "sibling") shouldTestNextSiblings = true;
+				}
+				return compileRules(rules, options, context);
+			})
+			.reduce(reduceRules, falseFunc);
+
+		query.shouldTestNextSiblings = shouldTestNextSiblings;
+
+		return query;
+	}
+
+	function isTraversal(t){
+		return procedure[t.type] < 0;
+	}
+
+	function compileRules(rules, options, context){
+		return rules.reduce(function(func, rule){
+			if(func === falseFunc) return func;
+			return Rules[rule.type](func, rule, options, context);
+		}, options && options.rootFunc || trueFunc);
+	}
+
+	function reduceRules(a, b){
+		if(b === falseFunc || a === trueFunc){
+			return a;
 		}
+		if(a === falseFunc || b === trueFunc){
+			return b;
+		}
+
+		return function combine(elem){
+			return a(elem) || b(elem);
+		};
 	}
 
-	var func = compileToken(token, opts, context);
+	function containsTraversal(t){
+		return t.some(isTraversal);
+	}
 
-	if(func === falseFunc) return next;
-	if(func === trueFunc)  return falseFunc;
+	//:not, :has and :matches have to compile selectors
+	//doing this in lib/pseudos.js would lead to circular dependencies,
+	//so we add them here
+	filters.not = function(next, token, options, context){
+		var opts = {
+			xmlMode: !!(options && options.xmlMode),
+			strict: !!(options && options.strict)
+		};
 
-	return function(elem){
-		return !func(elem) && next(elem);
-	};
-};
+		if(opts.strict){
+			if(token.length > 1 || token.some(containsTraversal)){
+				throw new Error("complex selectors in :not aren't allowed in strict mode");
+			}
+		}
 
-filters.has = function(next, token, options){
-	var opts = {
-		xmlMode: !!(options && options.xmlMode),
-		strict: !!(options && options.strict)
-	};
+		var func = compileToken(token, opts, context);
 
-	//FIXME: Uses an array as a pointer to the current element (side effects)
-	var context = token.some(containsTraversal) ? [PLACEHOLDER_ELEMENT] : null;
+		if(func === falseFunc) return next;
+		if(func === trueFunc)  return falseFunc;
 
-	var func = compileToken(token, opts, context);
-
-	if(func === falseFunc) return falseFunc;
-	if(func === trueFunc)  {
 		return function(elem){
-			return getChildren(elem).some(isTag) && next(elem);
+			return !func(elem) && next(elem);
 		};
-	}
+	};
 
-	func = wrap(func);
+	filters.has = function(next, token, options){
+		var opts = {
+			xmlMode: !!(options && options.xmlMode),
+			strict: !!(options && options.strict)
+		};
 
-	if(context){
+		//FIXME: Uses an array as a pointer to the current element (side effects)
+		var context = token.some(containsTraversal) ? [PLACEHOLDER_ELEMENT] : null;
+
+		var func = compileToken(token, opts, context);
+
+		if(func === falseFunc) return falseFunc;
+		if(func === trueFunc)  {
+			return function(elem){
+				return adapter.getChildren(elem).some(adapter.isTag) && next(elem);
+			};
+		}
+
+		func = wrap(func);
+
+		if(context){
+			return function has(elem){
+				return next(elem) && (
+					(context[0] = elem), adapter.existsOne(func, adapter.getChildren(elem))
+				);
+			};
+		}
+
 		return function has(elem){
-			return next(elem) && (
-				(context[0] = elem), existsOne(func, getChildren(elem))
-			);
+			return next(elem) && adapter.existsOne(func, adapter.getChildren(elem));
 		};
-	}
-
-	return function has(elem){
-		return next(elem) && existsOne(func, getChildren(elem));
-	};
-};
-
-filters.matches = function(next, token, options, context){
-	var opts = {
-		xmlMode: !!(options && options.xmlMode),
-		strict: !!(options && options.strict),
-		rootFunc: next
 	};
 
-	return compileToken(token, opts, context);
-};
+	filters.matches = function(next, token, options, context){
+		var opts = {
+			xmlMode: !!(options && options.xmlMode),
+			strict: !!(options && options.strict),
+			rootFunc: next
+		};
+
+		return compileToken(token, opts, context);
+	};
+
+	compile.compileToken = compileToken;
+	compile.compileUnsafe = compileUnsafe;
+	compile.Pseudos = Pseudos;
+
+	return compile;
+}

--- a/lib/general.js
+++ b/lib/general.js
@@ -1,100 +1,99 @@
-var DomUtils    = require("domutils"),
-    isTag       = DomUtils.isTag,
-    getParent   = DomUtils.getParent,
-    getChildren = DomUtils.getChildren,
-    getSiblings = DomUtils.getSiblings,
-    getName     = DomUtils.getName;
+var attributeFactory = require("./attributes.js");
 
-/*
-	all available rules
-*/
-module.exports = {
-	__proto__: null,
+function generalFactory(adapter, Pseudos){
+	/*
+		all available rules
+	*/
+	return {
+		__proto__: null,
 
-	attribute: require("./attributes.js").compile,
-	pseudo: require("./pseudos.js").compile,
+		attribute: attributeFactory(adapter).compile,
+		pseudo: Pseudos.compile,
 
-	//tags
-	tag: function(next, data){
-		var name = data.name;
-		return function tag(elem){
-			return getName(elem) === name && next(elem);
-		};
-	},
+		//tags
+		tag: function(next, data){
+			var name = data.name;
+			return function tag(elem){
+				return adapter.getName(elem) === name && next(elem);
+			};
+		},
 
-	//traversal
-	descendant: function(next){
-		return function descendant(elem){
+		//traversal
+		descendant: function(next){
+			return function descendant(elem){
 
-			var found = false;
+				var found = false;
 
-			while(!found && (elem = getParent(elem))){
-				found = next(elem);
+				while(!found && (elem = adapter.getParent(elem))){
+					found = next(elem);
+				}
+
+				return found;
+			};
+		},
+		_flexibleDescendant: function(next){
+			// Include element itself, only used while querying an array
+			return function descendant(elem){
+
+				var found = next(elem);
+
+				while(!found && (elem = adapter.getParent(elem))){
+					found = next(elem);
+				}
+
+				return found;
+			};
+		},
+		parent: function(next, data, options){
+			if(options && options.strict) throw new Error("Parent selector isn't part of CSS3");
+
+			return function parent(elem){
+				return adapter.getChildren(elem).some(test);
+			};
+
+			function test(elem){
+				return adapter.isTag(elem) && next(elem);
 			}
+		},
+		child: function(next){
+			return function child(elem){
+				var parent = adapter.getParent(elem);
+				return !!parent && next(parent);
+			};
+		},
+		sibling: function(next){
+			return function sibling(elem){
+				var siblings = adapter.getSiblings(elem);
 
-			return found;
-		};
-	},
-	_flexibleDescendant: function(next){
-		// Include element itself, only used while querying an array
-		return function descendant(elem){
+				for(var i = 0; i < siblings.length; i++){
+					if(adapter.isTag(siblings[i])){
+						if(siblings[i] === elem) break;
+						if(next(siblings[i])) return true;
+					}
+				}
 
-			var found = next(elem);
+				return false;
+			};
+		},
+		adjacent: function(next){
+			return function adjacent(elem){
+				var siblings = adapter.getSiblings(elem),
+						lastElement;
 
-			while(!found && (elem = getParent(elem))){
-				found = next(elem);
-			}
+				for(var i = 0; i < siblings.length; i++){
+					if(adapter.isTag(siblings[i])){
+						if(siblings[i] === elem) break;
+						lastElement = siblings[i];
+					}
+				}
 
-			return found;
-		};
-	},
-	parent: function(next, data, options){
-		if(options && options.strict) throw new Error("Parent selector isn't part of CSS3");
-
-		return function parent(elem){
-			return getChildren(elem).some(test);
-		};
-
-		function test(elem){
-			return isTag(elem) && next(elem);
+				return !!lastElement && next(lastElement);
+			};
+		},
+		universal: function(next){
+			return next;
 		}
-	},
-	child: function(next){
-		return function child(elem){
-			var parent = getParent(elem);
-			return !!parent && next(parent);
-		};
-	},
-	sibling: function(next){
-		return function sibling(elem){
-			var siblings = getSiblings(elem);
+	};
+}
 
-			for(var i = 0; i < siblings.length; i++){
-				if(isTag(siblings[i])){
-					if(siblings[i] === elem) break;
-					if(next(siblings[i])) return true;
-				}
-			}
-
-			return false;
-		};
-	},
-	adjacent: function(next){
-		return function adjacent(elem){
-			var siblings = getSiblings(elem),
-			    lastElement;
-
-			for(var i = 0; i < siblings.length; i++){
-				if(isTag(siblings[i])){
-					if(siblings[i] === elem) break;
-					lastElement = siblings[i];
-				}
-			}
-
-			return !!lastElement && next(lastElement);
-		};
-	},
-	universal: function(next){
-		return next;
-	}
-};
+module.exports = generalFactory;

--- a/lib/pseudos.js
+++ b/lib/pseudos.js
@@ -12,8 +12,8 @@
 */
 
 var getNCheck         = require("nth-check"),
-		BaseFuncs         = require("boolbase"),
-		attributesFactory = require("./attributes.js"),
+    BaseFuncs         = require("boolbase"),
+    attributesFactory = require("./attributes.js"),
     trueFunc          = BaseFuncs.trueFunc,
     falseFunc         = BaseFuncs.falseFunc;
 

--- a/lib/pseudos.js
+++ b/lib/pseudos.js
@@ -11,342 +11,350 @@
 	  they need to return a boolean
 */
 
-var DomUtils     = require("domutils"),
-    isTag        = DomUtils.isTag,
-    getText      = DomUtils.getText,
-    getParent    = DomUtils.getParent,
-    getChildren  = DomUtils.getChildren,
-    getSiblings  = DomUtils.getSiblings,
-    hasAttrib    = DomUtils.hasAttrib,
-    getName      = DomUtils.getName,
-    getAttribute = DomUtils.getAttributeValue,
-    getNCheck    = require("nth-check"),
-    checkAttrib  = require("./attributes.js").rules.equals,
-    BaseFuncs    = require("boolbase"),
-    trueFunc     = BaseFuncs.trueFunc,
-    falseFunc    = BaseFuncs.falseFunc;
+var getNCheck         = require("nth-check"),
+		BaseFuncs         = require("boolbase"),
+		attributesFactory = require("./attributes.js"),
+    trueFunc          = BaseFuncs.trueFunc,
+    falseFunc         = BaseFuncs.falseFunc;
 
-//helper methods
-function getFirstElement(elems){
-	for(var i = 0; elems && i < elems.length; i++){
-		if(isTag(elems[i])) return elems[i];
+function filtersFactory(adapter){
+	var attributes  = attributesFactory(adapter),
+			checkAttrib = attributes.rules.equals;
+
+	//helper methods
+	function equals( a, b ){
+		if( typeof adapter.equals === 'function' ) return adapter.equals( a, b );
+
+		return a === b;
 	}
-}
 
-function getAttribFunc(name, value){
-	var data = {name: name, value: value};
-	return function attribFunc(next){
-		return checkAttrib(next, data);
-	};
-}
-
-function getChildFunc(next){
-	return function(elem){
-		return !!getParent(elem) && next(elem);
-	};
-}
-
-var filters = {
-	contains: function(next, text){
-		return function contains(elem){
-			return next(elem) && getText(elem).indexOf(text) >= 0;
+	function getAttribFunc(name, value){
+		var data = {name: name, value: value};
+		return function attribFunc(next){
+			return checkAttrib(next, data);
 		};
-	},
-	icontains: function(next, text){
-		var itext = text.toLowerCase();
-		return function icontains(elem){
-			return next(elem) &&
-				getText(elem).toLowerCase().indexOf(itext) >= 0;
-		};
-	},
+	}
 
-	//location specific methods
-	"nth-child": function(next, rule){
-		var func = getNCheck(rule);
-
-		if(func === falseFunc) return func;
-		if(func === trueFunc)  return getChildFunc(next);
-
-		return function nthChild(elem){
-			var siblings = getSiblings(elem);
-
-			for(var i = 0, pos = 0; i < siblings.length; i++){
-				if(isTag(siblings[i])){
-					if(siblings[i] === elem) break;
-					else pos++;
-				}
-			}
-
-			return func(pos) && next(elem);
-		};
-	},
-	"nth-last-child": function(next, rule){
-		var func = getNCheck(rule);
-
-		if(func === falseFunc) return func;
-		if(func === trueFunc)  return getChildFunc(next);
-
-		return function nthLastChild(elem){
-			var siblings = getSiblings(elem);
-
-			for(var pos = 0, i = siblings.length - 1; i >= 0; i--){
-				if(isTag(siblings[i])){
-					if(siblings[i] === elem) break;
-					else pos++;
-				}
-			}
-
-			return func(pos) && next(elem);
-		};
-	},
-	"nth-of-type": function(next, rule){
-		var func = getNCheck(rule);
-
-		if(func === falseFunc) return func;
-		if(func === trueFunc)  return getChildFunc(next);
-
-		return function nthOfType(elem){
-			var siblings = getSiblings(elem);
-
-			for(var pos = 0, i = 0; i < siblings.length; i++){
-				if(isTag(siblings[i])){
-					if(siblings[i] === elem) break;
-					if(getName(siblings[i]) === getName(elem)) pos++;
-				}
-			}
-
-			return func(pos) && next(elem);
-		};
-	},
-	"nth-last-of-type": function(next, rule){
-		var func = getNCheck(rule);
-
-		if(func === falseFunc) return func;
-		if(func === trueFunc)  return getChildFunc(next);
-
-		return function nthLastOfType(elem){
-			var siblings = getSiblings(elem);
-
-			for(var pos = 0, i = siblings.length - 1; i >= 0; i--){
-				if(isTag(siblings[i])){
-					if(siblings[i] === elem) break;
-					if(getName(siblings[i]) === getName(elem)) pos++;
-				}
-			}
-
-			return func(pos) && next(elem);
-		};
-	},
-
-	//TODO determine the actual root element
-	root: function(next){
+	function getChildFunc(next){
 		return function(elem){
-			return !getParent(elem) && next(elem);
+			return !!adapter.getParent(elem) && next(elem);
 		};
-	},
+	}
 
-	scope: function(next, rule, options, context){
-		if(!context || context.length === 0){
-			//equivalent to :root
-			return filters.root(next);
-		}
-
-		if(context.length === 1){
-			//NOTE: can't be unpacked, as :has uses this for side-effects
-			return function(elem){
-				return context[0] === elem && next(elem);
+	var filters = {
+		contains: function(next, text){
+			return function contains(elem){
+				return next(elem) && adapter.getText(elem).indexOf(text) >= 0;
 			};
+		},
+		icontains: function(next, text){
+			var itext = text.toLowerCase();
+			return function icontains(elem){
+				return next(elem) &&
+					adapter.getText(elem).toLowerCase().indexOf(itext) >= 0;
+			};
+		},
+
+		//location specific methods
+		"nth-child": function(next, rule){
+			var func = getNCheck(rule);
+
+			if(func === falseFunc) return func;
+			if(func === trueFunc)  return getChildFunc(next);
+
+			return function nthChild(elem){
+				var siblings = adapter.getSiblings(elem);
+
+				for(var i = 0, pos = 0; i < siblings.length; i++){
+					if(adapter.isTag(siblings[i])){
+						if(siblings[i] === elem) break;
+						else pos++;
+					}
+				}
+
+				return func(pos) && next(elem);
+			};
+		},
+		"nth-last-child": function(next, rule){
+			var func = getNCheck(rule);
+
+			if(func === falseFunc) return func;
+			if(func === trueFunc)  return getChildFunc(next);
+
+			return function nthLastChild(elem){
+				var siblings = adapter.getSiblings(elem);
+
+				for(var pos = 0, i = siblings.length - 1; i >= 0; i--){
+					if(adapter.isTag(siblings[i])){
+						if(siblings[i] === elem) break;
+						else pos++;
+					}
+				}
+
+				return func(pos) && next(elem);
+			};
+		},
+		"nth-of-type": function(next, rule){
+			var func = getNCheck(rule);
+
+			if(func === falseFunc) return func;
+			if(func === trueFunc)  return getChildFunc(next);
+
+			return function nthOfType(elem){
+				var siblings = adapter.getSiblings(elem);
+
+				for(var pos = 0, i = 0; i < siblings.length; i++){
+					if(adapter.isTag(siblings[i])){
+						if(siblings[i] === elem) break;
+						if(adapter.getName(siblings[i]) === adapter.getName(elem)) pos++;
+					}
+				}
+
+				return func(pos) && next(elem);
+			};
+		},
+		"nth-last-of-type": function(next, rule){
+			var func = getNCheck(rule);
+
+			if(func === falseFunc) return func;
+			if(func === trueFunc)  return getChildFunc(next);
+
+			return function nthLastOfType(elem){
+				var siblings = adapter.getSiblings(elem);
+
+				for(var pos = 0, i = siblings.length - 1; i >= 0; i--){
+					if(adapter.isTag(siblings[i])){
+						if(siblings[i] === elem) break;
+						if(adapter.getName(siblings[i]) === adapter.getName(elem)) pos++;
+					}
+				}
+
+				return func(pos) && next(elem);
+			};
+		},
+
+		//TODO determine the actual root element
+		root: function(next){
+			return function(elem){
+				return !adapter.getParent(elem) && next(elem);
+			};
+		},
+
+		scope: function(next, rule, options, context){
+			if(!context || context.length === 0){
+				//equivalent to :root
+				return filters.root(next);
+			}
+
+			if(context.length === 1){
+				//NOTE: can't be unpacked, as :has uses this for side-effects
+				return function(elem){
+					return equals( context[0], elem ) && next(elem);
+				};
+			}
+
+			return function(elem){
+				return context.indexOf(elem) >= 0 && next(elem);
+			};
+		},
+
+		//jQuery extensions (others follow as pseudos)
+		checkbox: getAttribFunc("type", "checkbox"),
+		file: getAttribFunc("type", "file"),
+		password: getAttribFunc("type", "password"),
+		radio: getAttribFunc("type", "radio"),
+		reset: getAttribFunc("type", "reset"),
+		image: getAttribFunc("type", "image"),
+		submit: getAttribFunc("type", "submit")
+	};
+	return filters;
+}
+
+function pseudosFactory(adapter){
+	//helper methods
+	function getFirstElement(elems){
+		for(var i = 0; elems && i < elems.length; i++){
+			if(adapter.isTag(elems[i])) return elems[i];
 		}
+	}
 
-		return function(elem){
-			return context.indexOf(elem) >= 0 && next(elem);
-		};
-	},
+	//while filters are precompiled, pseudos get called when they are needed
+	var pseudos = {
+		empty: function(elem){
+			return !adapter.getChildren(elem).some(function(elem){
+				return adapter.isTag(elem) || elem.type === "text";
+			});
+		},
 
-	//jQuery extensions (others follow as pseudos)
-	checkbox: getAttribFunc("type", "checkbox"),
-	file: getAttribFunc("type", "file"),
-	password: getAttribFunc("type", "password"),
-	radio: getAttribFunc("type", "radio"),
-	reset: getAttribFunc("type", "reset"),
-	image: getAttribFunc("type", "image"),
-	submit: getAttribFunc("type", "submit")
-};
+		"first-child": function(elem){
+			return getFirstElement(adapter.getSiblings(elem)) === elem;
+		},
+		"last-child": function(elem){
+			var siblings = adapter.getSiblings(elem);
 
-//while filters are precompiled, pseudos get called when they are needed
-var pseudos = {
-	empty: function(elem){
-		return !getChildren(elem).some(function(elem){
-			return isTag(elem) || elem.type === "text";
-		});
-	},
-
-	"first-child": function(elem){
-		return getFirstElement(getSiblings(elem)) === elem;
-	},
-	"last-child": function(elem){
-		var siblings = getSiblings(elem);
-
-		for(var i = siblings.length - 1; i >= 0; i--){
-			if(siblings[i] === elem) return true;
-			if(isTag(siblings[i])) break;
-		}
-
-		return false;
-	},
-	"first-of-type": function(elem){
-		var siblings = getSiblings(elem);
-
-		for(var i = 0; i < siblings.length; i++){
-			if(isTag(siblings[i])){
+			for(var i = siblings.length - 1; i >= 0; i--){
 				if(siblings[i] === elem) return true;
-				if(getName(siblings[i]) === getName(elem)) break;
+				if(adapter.isTag(siblings[i])) break;
 			}
-		}
 
-		return false;
-	},
-	"last-of-type": function(elem){
-		var siblings = getSiblings(elem);
+			return false;
+		},
+		"first-of-type": function(elem){
+			var siblings = adapter.getSiblings(elem);
 
-		for(var i = siblings.length - 1; i >= 0; i--){
-			if(isTag(siblings[i])){
-				if(siblings[i] === elem) return true;
-				if(getName(siblings[i]) === getName(elem)) break;
-			}
-		}
-
-		return false;
-	},
-	"only-of-type": function(elem){
-		var siblings = getSiblings(elem);
-
-		for(var i = 0, j = siblings.length; i < j; i++){
-			if(isTag(siblings[i])){
-				if(siblings[i] === elem) continue;
-				if(getName(siblings[i]) === getName(elem)) return false;
-			}
-		}
-
-		return true;
-	},
-	"only-child": function(elem){
-		var siblings = getSiblings(elem);
-
-		for(var i = 0; i < siblings.length; i++){
-			if(isTag(siblings[i]) && siblings[i] !== elem) return false;
-		}
-
-		return true;
-	},
-
-	//:matches(a, area, link)[href]
-	link: function(elem){
-		return hasAttrib(elem, "href");
-	},
-	visited: falseFunc, //seems to be a valid implementation
-	//TODO: :any-link once the name is finalized (as an alias of :link)
-
-	//forms
-	//to consider: :target
-
-	//:matches([selected], select:not([multiple]):not(> option[selected]) > option:first-of-type)
-	selected: function(elem){
-		if(hasAttrib(elem, "selected")) return true;
-		else if(getName(elem) !== "option") return false;
-
-		//the first <option> in a <select> is also selected
-		var parent = getParent(elem);
-
-		if(
-			!parent ||
-			getName(parent) !== "select" ||
-			hasAttrib(parent, "multiple")
-		) return false;
-
-		var siblings = getChildren(parent),
-		    sawElem  = false;
-
-		for(var i = 0; i < siblings.length; i++){
-			if(isTag(siblings[i])){
-				if(siblings[i] === elem){
-					sawElem = true;
-				} else if(!sawElem){
-					return false;
-				} else if(hasAttrib(siblings[i], "selected")){
-					return false;
+			for(var i = 0; i < siblings.length; i++){
+				if(adapter.isTag(siblings[i])){
+					if(siblings[i] === elem) return true;
+					if(adapter.getName(siblings[i]) === adapter.getName(elem)) break;
 				}
 			}
+
+			return false;
+		},
+		"last-of-type": function(elem){
+			var siblings = adapter.getSiblings(elem);
+
+			for(var i = siblings.length - 1; i >= 0; i--){
+				if(adapter.isTag(siblings[i])){
+					if(siblings[i] === elem) return true;
+					if(adapter.getName(siblings[i]) === adapter.getName(elem)) break;
+				}
+			}
+
+			return false;
+		},
+		"only-of-type": function(elem){
+			var siblings = adapter.getSiblings(elem);
+
+			for(var i = 0, j = siblings.length; i < j; i++){
+				if(adapter.isTag(siblings[i])){
+					if(siblings[i] === elem) continue;
+					if(adapter.getName(siblings[i]) === adapter.getName(elem)) return false;
+				}
+			}
+
+			return true;
+		},
+		"only-child": function(elem){
+			var siblings = adapter.getSiblings(elem);
+
+			for(var i = 0; i < siblings.length; i++){
+				if(adapter.isTag(siblings[i]) && siblings[i] !== elem) return false;
+			}
+
+			return true;
+		},
+
+		//:matches(a, area, link)[href]
+		link: function(elem){
+			return adapter.hasAttrib(elem, "href");
+		},
+		visited: falseFunc, //seems to be a valid implementation
+		//TODO: :any-link once the name is finalized (as an alias of :link)
+
+		//forms
+		//to consider: :target
+
+		//:matches([selected], select:not([multiple]):not(> option[selected]) > option:first-of-type)
+		selected: function(elem){
+			if(adapter.hasAttrib(elem, "selected")) return true;
+			else if(adapter.getName(elem) !== "option") return false;
+
+			//the first <option> in a <select> is also selected
+			var parent = adapter.getParent(elem);
+
+			if(
+				!parent ||
+				adapter.getName(parent) !== "select" ||
+				adapter.hasAttrib(parent, "multiple")
+			) return false;
+
+			var siblings = adapter.getChildren(parent),
+					sawElem  = false;
+
+			for(var i = 0; i < siblings.length; i++){
+				if(adapter.isTag(siblings[i])){
+					if(siblings[i] === elem){
+						sawElem = true;
+					} else if(!sawElem){
+						return false;
+					} else if(adapter.hasAttrib(siblings[i], "selected")){
+						return false;
+					}
+				}
+			}
+
+			return sawElem;
+		},
+		//https://html.spec.whatwg.org/multipage/scripting.html#disabled-elements
+		//:matches(
+		//  :matches(button, input, select, textarea, menuitem, optgroup, option)[disabled],
+		//  optgroup[disabled] > option),
+		// fieldset[disabled] * //TODO not child of first <legend>
+		//)
+		disabled: function(elem){
+			return adapter.hasAttrib(elem, "disabled");
+		},
+		enabled: function(elem){
+			return !adapter.hasAttrib(elem, "disabled");
+		},
+		//:matches(:matches(:radio, :checkbox)[checked], :selected) (TODO menuitem)
+		checked: function(elem){
+			return adapter.hasAttrib(elem, "checked") || pseudos.selected(elem);
+		},
+		//:matches(input, select, textarea)[required]
+		required: function(elem){
+			return adapter.hasAttrib(elem, "required");
+		},
+		//:matches(input, select, textarea):not([required])
+		optional: function(elem){
+			return !adapter.hasAttrib(elem, "required");
+		},
+
+		//jQuery extensions
+
+		//:not(:empty)
+		parent: function(elem){
+			return !pseudos.empty(elem);
+		},
+		//:matches(h1, h2, h3, h4, h5, h6)
+		header: function(elem){
+			var name = adapter.getName(elem);
+			return name === "h1" ||
+					name === "h2" ||
+					name === "h3" ||
+					name === "h4" ||
+					name === "h5" ||
+					name === "h6";
+		},
+
+		//:matches(button, input[type=button])
+		button: function(elem){
+			var name = adapter.getName(elem);
+			return name === "button" ||
+					name === "input" &&
+					adapter.getAttributeValue(elem, "type") === "button";
+		},
+		//:matches(input, textarea, select, button)
+		input: function(elem){
+			var name = adapter.getName(elem);
+			return name === "input" ||
+					name === "textarea" ||
+					name === "select" ||
+					name === "button";
+		},
+		//input:matches(:not([type!='']), [type='text' i])
+		text: function(elem){
+			var attr;
+			return adapter.getName(elem) === "input" && (
+				!(attr = adapter.getAttributeValue(elem, "type")) ||
+				attr.toLowerCase() === "text"
+			);
 		}
+	};
 
-		return sawElem;
-	},
-	//https://html.spec.whatwg.org/multipage/scripting.html#disabled-elements
-	//:matches(
-	//  :matches(button, input, select, textarea, menuitem, optgroup, option)[disabled],
-	//  optgroup[disabled] > option),
-	// fieldset[disabled] * //TODO not child of first <legend>
-	//)
-	disabled: function(elem){
-		return hasAttrib(elem, "disabled");
-	},
-	enabled: function(elem){
-		return !hasAttrib(elem, "disabled");
-	},
-	//:matches(:matches(:radio, :checkbox)[checked], :selected) (TODO menuitem)
-	checked: function(elem){
-		return hasAttrib(elem, "checked") || pseudos.selected(elem);
-	},
-	//:matches(input, select, textarea)[required]
-	required: function(elem){
-		return hasAttrib(elem, "required");
-	},
-	//:matches(input, select, textarea):not([required])
-	optional: function(elem){
-		return !hasAttrib(elem, "required");
-	},
-
-	//jQuery extensions
-
-	//:not(:empty)
-	parent: function(elem){
-		return !pseudos.empty(elem);
-	},
-	//:matches(h1, h2, h3, h4, h5, h6)
-	header: function(elem){
-		var name = getName(elem);
-		return name === "h1" ||
-			   name === "h2" ||
-			   name === "h3" ||
-			   name === "h4" ||
-			   name === "h5" ||
-			   name === "h6";
-	},
-
-	//:matches(button, input[type=button])
-	button: function(elem){
-		var name = getName(elem);
-		return name === "button" ||
-			   name === "input" &&
-			   getAttribute(elem, "type") === "button";
-	},
-	//:matches(input, textarea, select, button)
-	input: function(elem){
-		var name = getName(elem);
-		return name === "input" ||
-			   name === "textarea" ||
-			   name === "select" ||
-			   name === "button";
-	},
-	//input:matches(:not([type!='']), [type='text' i])
-	text: function(elem){
-		var attr;
-		return getName(elem) === "input" && (
-			!(attr = getAttribute(elem, "type")) ||
-			attr.toLowerCase() === "text"
-		);
-	}
-};
+	return pseudos;
+}
 
 function verifyArgs(func, name, subselect){
 	if(subselect === null){
@@ -363,31 +371,38 @@ function verifyArgs(func, name, subselect){
 //FIXME this feels hacky
 var re_CSS3 = /^(?:(?:nth|last|first|only)-(?:child|of-type)|root|empty|(?:en|dis)abled|checked|not)$/;
 
-module.exports = {
-	compile: function(next, data, options, context){
-		var name = data.name,
-		    subselect = data.data;
+function factory(adapter){
+	var pseudos = pseudosFactory(adapter);
+	var filters = filtersFactory(adapter);
 
-		if(options && options.strict && !re_CSS3.test(name)){
-			throw new Error(":" + name + " isn't part of CSS3");
-		}
+	return {
+		compile: function(next, data, options, context){
+			var name = data.name,
+					subselect = data.data;
 
-		if(typeof filters[name] === "function"){
-			verifyArgs(filters[name], name,  subselect);
-			return filters[name](next, subselect, options, context);
-		} else if(typeof pseudos[name] === "function"){
-			var func = pseudos[name];
-			verifyArgs(func, name, subselect);
+			if(options && options.strict && !re_CSS3.test(name)){
+				throw new Error(":" + name + " isn't part of CSS3");
+			}
 
-			if(next === trueFunc) return func;
+			if(typeof filters[name] === "function"){
+				verifyArgs(filters[name], name,  subselect);
+				return filters[name](next, subselect, options, context);
+			} else if(typeof pseudos[name] === "function"){
+				var func = pseudos[name];
+				verifyArgs(func, name, subselect);
 
-			return function pseudoArgs(elem){
-				return func(elem, subselect) && next(elem);
-			};
-		} else {
-			throw new Error("unmatched pseudo-class :" + name);
-		}
-	},
-	filters: filters,
-	pseudos: pseudos
-};
+				if(next === trueFunc) return func;
+
+				return function pseudoArgs(elem){
+					return func(elem, subselect) && next(elem);
+				};
+			} else {
+				throw new Error("unmatched pseudo-class :" + name);
+			}
+		},
+		filters: filters,
+		pseudos: pseudos
+	};
+}
+
+module.exports = factory;

--- a/package.json
+++ b/package.json
@@ -23,14 +23,15 @@
     "nth-check": "^1.0.1"
   },
   "devDependencies": {
-    "htmlparser2": "*",
     "cheerio-soupselect": "*",
-    "eslint": "^3.0.0",
-    "mocha": "*",
-    "mocha-lcov-reporter": "*",
     "coveralls": "*",
+    "eslint": "^3.0.0",
+    "expect.js": "*",
+    "htmlparser2": "*",
     "istanbul": "*",
-    "expect.js": "*"
+    "jsdom": "^9.6.0",
+    "mocha": "*",
+    "mocha-lcov-reporter": "*"
   },
   "scripts": {
     "test": "mocha && npm run lint",

--- a/test/adapter.js
+++ b/test/adapter.js
@@ -1,0 +1,92 @@
+var CSSselect = require( '..' ),
+    adapter   = require( '../browser-adapter' ),
+    jsdom     = require( 'jsdom' ),
+    assert    = require("assert");
+
+var html = '<main><div></div><div class="apple"></div><span><strong>Hello</strong>, <em>World!</em></span></main>';
+
+function getBody( html ){
+  return jsdom.jsdom( html ).defaultView.document.querySelector( 'body' );
+}
+
+describe( 'Browser Adapter', function(){
+  /*
+    isTag, existsOne, getAttributeValue, getChildren, getName, getParent,
+    getSiblings, getText, hasAttrib, removeSubsets, findAll, equals
+  */
+
+  it( 'should isTag', function(){
+    var body = getBody( html );
+
+    assert( adapter.isTag( body ) );
+  });
+
+  it( 'should existsOne', function(){
+    var body = getBody( html );
+    var divs = body.querySelectorAll( 'div' );
+    var arr = Array.from( divs );
+
+    var hasDiv = adapter.existsOne( function( node ){
+      return node.classList.contains( 'apple' );
+    }, arr );
+
+    assert( hasDiv );
+  });
+
+  it( 'should getAttributeValue', function(){
+    var body = getBody( html );
+    var div = body.querySelector( '.apple' );
+    var value = adapter.getAttributeValue( div, 'class' );
+
+    assert.equal( value, 'apple' );
+  });
+
+  it( 'should getChildren', function(){
+    var body = getBody( html );
+    var main = body.querySelector( 'main' );
+    var children = adapter.getChildren( main );
+
+    assert( Array.isArray( children ) );
+    assert.equal( children.length, 3 );
+  });
+
+  it( 'should getName', function(){
+    var body = getBody( html );
+
+    assert.equal( adapter.getName( body ), 'body' );
+  });
+
+  it( 'should getParent', function(){
+    var body = getBody( html );
+    var main = body.querySelector( 'main' );
+
+    assert.equal( body, adapter.getParent( main ) );
+  });
+
+  it( 'should getSiblings', function(){
+    var body = getBody( html );
+    var div = body.querySelector( 'div' );
+
+    var siblings = adapter.getSiblings( div );
+
+    assert( Array.isArray( siblings ) );
+    assert.equal( siblings.length, 3 );
+  });
+
+  it( 'should getText', function(){
+    var body = getBody( html );
+    var span = body.querySelector( 'span' );
+
+    var text = adapter.getText( span );
+
+    assert.equal( text, 'Hello, World!' );
+  });
+
+  it( 'should hasAttrib', function(){
+    var body = getBody( html );
+    var apple = body.querySelector( '.apple' );
+
+    assert( adapter.hasAttrib( apple, 'class' ) );
+    assert( !adapter.hasAttrib( body, 'class' ) );
+  });
+});

--- a/test/adapter.js
+++ b/test/adapter.js
@@ -3,18 +3,13 @@ var CSSselect = require( '..' ),
     jsdom     = require( 'jsdom' ),
     assert    = require("assert");
 
-var html = '<main><div></div><div class="apple"></div><span><strong>Hello</strong>, <em>World!</em></span></main>';
+var html = '<main><div></div><div class="apple"></div><span class="pear potato"><strong id="cheese-burger">Hello</strong>, <em>World!</em></span></main>';
 
 function getBody( html ){
   return jsdom.jsdom( html ).defaultView.document.querySelector( 'body' );
 }
 
-describe( 'Browser Adapter', function(){
-  /*
-    isTag, existsOne, getAttributeValue, getChildren, getName, getParent,
-    getSiblings, getText, hasAttrib, removeSubsets, findAll, equals
-  */
-
+describe( 'Adapter API', function(){
   it( 'should isTag', function(){
     var body = getBody( html );
 
@@ -89,4 +84,191 @@ describe( 'Browser Adapter', function(){
     assert( adapter.hasAttrib( apple, 'class' ) );
     assert( !adapter.hasAttrib( body, 'class' ) );
   });
+
+  it( 'should removeSubsets', function(){
+    var body = getBody( html );
+    var divs = Array.from( body.querySelectorAll( 'div' ) );
+    var apple = body.querySelector( '.apple' );
+    var span = body.querySelector( 'span' );
+    var strong = body.querySelector( 'strong' );
+
+    var nonset = divs.concat( [ apple, span, strong ] );
+
+    var set = adapter.removeSubsets( nonset );
+
+    assert.equal( set.length, 3 );
+  });
+
+  it( 'should findAll', function(){
+    var body = getBody( html );
+    var els = body.querySelectorAll( 'main > *' );
+    var arr = Array.from( els );
+
+    var classEls = adapter.findAll( function( node ){
+      return adapter.hasAttrib( node, 'class' );
+    }, arr );
+
+    assert.equal( classEls.length, 2 );    
+  });
+});
+
+describe( 'Adapter Select', function(){
+  var options = { adapter: adapter };
+
+  it( 'should universal', function(){
+    var body = getBody( html );
+    var universal = CSSselect( '*', body, options );
+
+    assert.equal( universal.length, 6 );
+  });
+
+  it( 'should tag', function(){
+    var body = getBody( html );
+    var tag = CSSselect( 'div', body, options );
+
+    assert.equal( tag.length, 2 );    
+  });
+
+  it( 'should descendant', function(){
+    var body = getBody( html );
+    var descendant = CSSselect( 'main div', body, options );
+
+    assert.equal( descendant.length, 2 );        
+  });
+
+  it( 'should child', function(){
+    var body = getBody( html );
+    var child = CSSselect( 'main > div', body, options );
+
+    assert.equal( child.length, 2 );        
+  });
+
+  it( 'should parent', function(){
+    var body = getBody( html );
+    var parent = CSSselect( 'div < main', body, options );
+
+    assert.equal( parent.length, 1 );        
+  });
+
+  it( 'should sibling', function(){
+    var body = getBody( html );
+    var sibling = CSSselect( 'div + span', body, options );
+
+    assert.equal( sibling.length, 1 );    
+  });
+
+  it( 'should adjacent', function(){
+    var body = getBody( html );
+    var adjacent = CSSselect( 'strong ~ em', body, options );
+
+    assert.equal( adjacent.length, 1 );    
+  });
+
+  it( 'should attribute', function(){
+    var body = getBody( html );
+    var attribute = CSSselect( '[class]', body, options );
+
+    assert.equal( attribute.length, 2 );    
+  });
+
+  it( 'should attribute =', function(){
+    var body = getBody( html );
+    var attribute = CSSselect( '[class="apple"]', body, options );
+
+    assert.equal( attribute.length, 1 );    
+  });
+
+  it( 'should attribute ~=', function(){
+    var body = getBody( html );
+    var attribute = CSSselect( '[class~="potato"]', body, options );
+
+    assert.equal( attribute.length, 1 );    
+  });  
+
+  it( 'should attribute |=', function(){
+    var body = getBody( html );
+    var attribute = CSSselect( '[id|="cheese"]', body, options );
+
+    assert.equal( attribute.length, 1 );    
+  });  
+
+  it( 'should attribute *=', function(){
+    var body = getBody( html );
+    var attribute = CSSselect( '[id*="ee"]', body, options );
+
+    assert.equal( attribute.length, 1 );    
+  });  
+
+  it( 'should attribute ^=', function(){
+    var body = getBody( html );
+    var attribute = CSSselect( '[id^="ch"]', body, options );
+
+    assert.equal( attribute.length, 1 );    
+  });  
+
+  it( 'should attribute $=', function(){
+    var body = getBody( html );
+    var attribute = CSSselect( '[id$="burger"]', body, options );
+
+    assert.equal( attribute.length, 1 );    
+  }); 
+
+  it( 'should attribute !=', function(){
+    var body = getBody( html );
+    var attribute = CSSselect( 'div[class!="apple"]', body, options );
+
+    assert.equal( attribute.length, 1 );    
+  });  
+
+  it( 'should :not', function(){
+    var body = getBody( html );
+    var pseudo = CSSselect( 'div:not( .apple )', body, options );
+
+    assert.equal( pseudo.length, 1 );        
+  });
+
+  it( 'should :contains', function(){
+    var body = getBody( html );
+    var pseudo = CSSselect( ":contains(Hello)", body, options );
+
+    assert.equal( pseudo.length, 3 );        
+  });
+
+  it( 'should :icontains', function(){
+    var body = getBody( html );
+    var pseudo = CSSselect( ":icontains(HELLO)", body, options );
+
+    assert.equal( pseudo.length, 3 );        
+  });  
+
+  it( 'should :has', function(){
+    var body = getBody( html );
+    var pseudo = CSSselect( ":has( em )", body, options );
+
+    assert.equal( pseudo.length, 2 );        
+  });  
+
+  //TODO
+  /*
+  it( 'should :root', function(){
+    var body = getBody( html );
+    var pseudo = CSSselect( ":root", body, options );
+
+    assert.equal( pseudo.length, 1 );        
+  });
+  */
+
+  it( 'should :empty', function(){
+    var body = getBody( html );
+    var pseudo = CSSselect( "div:empty", body, options );
+
+    assert.equal( pseudo.length, 2 );        
+  });  
+
+  it( 'should :first-child', function(){
+    var body = getBody( html );
+    var pseudo = CSSselect( "div:first-child", body, options );
+
+    assert.equal( pseudo.length, 1 );        
+  });    
 });


### PR DESCRIPTION
- arbitrary backing dom structures via `options.adapter`
- no breaking changes, external API is the same
- uses domutils by default
- static methods on CSSselect always use domutils
- includes browser-adapter for browser DOM
- tests
- readme updated