### PR TITLE
changed domutils version to 1.6.2. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# tweak to get Travis-CI to build
+
 # css-select [![NPM version](http://img.shields.io/npm/v/css-select.svg)](https://npmjs.org/package/css-select) [![Build Status](https://travis-ci.org/fb55/css-select.svg?branch=master)](http://travis-ci.org/fb55/css-select) [![Downloads](https://img.shields.io/npm/dm/css-select.svg)](https://npmjs.org/package/css-select) [![Coverage](https://coveralls.io/repos/fb55/css-select/badge.svg?branch=master)](https://coveralls.io/r/fb55/css-select)
 
 a CSS selector compiler/engine

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "boolbase": "^1.0.0",
     "css-what": "2.1",
-    "domutils": "1.5.1",
+    "domutils": "1.6.2",
     "nth-check": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This is to address:-

* serious mem leak present in 1.5.0 - https://github.com/fb55/domutils/releases/tag/v1.5.0
* null child issue present in 1.6.0 - https://github.com/fb55/domutils/releases/tag/v1.6.0

Problem noted upstream in Cheerio. See previous npm-shrinkwrap.json for details of usage.

{
  "dependencies": {
    "cheerio": {
      "version": "~0.22.0",
      "from": "cheerio@~0.22.0",
      "dependencies": {
        "css-select":{
          "version":"1.2.0",
          "from":"css-select@1.2.0",
          "dependencies":{
            "domutils":{
              "version":"1.6.2",
              "from":"domutils@1.6.2"
            }
          }
        }
      }
    }
  }
}

Tested extensively with my own usecase, and where previously this was falling over after around 15-20 tasks, this now runs past 1000.

Cheers.
