### PR TITLE
avoid exponential time on selectors with many descendants 

### DIFF
--- a/lib/general.js
+++ b/lib/general.js
@@ -1,3 +1,4 @@
+var Set = require("es6-set");
 var attributeFactory = require("./attributes.js");
 
 function generalFactory(adapter, Pseudos){
@@ -20,12 +21,18 @@ function generalFactory(adapter, Pseudos){
 
 		//traversal
 		descendant: function(next){
-			return function descendant(elem){
+			var isFalseCache = new Set();
 
+			return function descendant(elem){
 				var found = false;
 
 				while(!found && (elem = adapter.getParent(elem))){
-					found = next(elem);
+					if(!isFalseCache.has(elem)){
+						found = next(elem);
+						if(!found){
+							isFalseCache.add(elem);
+						}
+					}
 				}
 
 				return found;

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "boolbase": "^1.0.0",
     "css-what": "2.1",
     "domutils": "1.5.1",
+    "es6-set": "^0.1.5",
     "nth-check": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR works by keeping a cache of of elements inside each descendant function for which the rest of the selector doesn't match. 

# Test code
* https://github.com/dbuezas/css-select-test

# Test page
* https://rawgit.com/dbuezas/css-select-test/master/test.html
(wait a couple of seconds to see results table)

# Issues: 
* https://github.com/cheeriojs/cheerio/issues/1118
* https://github.com/fb55/css-select/issues/93

# Results:
![image](https://user-images.githubusercontent.com/777196/34457865-d408fb64-edbe-11e7-870c-d82109f504a0.png)

# Notes:
* Native implementation of Set in chrome seems to be a tad faster than the one in Node.
* `es6-set` is just a polyfill and uses native implementation if available
