### PR TITLE
Use options to pass through adapters

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,7 @@
 {
   "extends": "eslint:recommended",
   "env": {
-    "node": true,
-    "es6": true
+    "node": true
   },
   "rules": {
   	"no-console": 0,

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,8 @@
 {
   "extends": "eslint:recommended",
   "env": {
-    "node": true
+    "node": true,
+    "es6": true
   },
   "rules": {
   	"no-console": 0,

--- a/lib/attributes.js
+++ b/lib/attributes.js
@@ -3,179 +3,198 @@ var falseFunc = require("boolbase").falseFunc;
 //https://github.com/slevithan/XRegExp/blob/master/src/xregexp.js#L469
 var reChars = /[-[\]{}()*+?.,\\^$|#\s]/g;
 
-function factory(adapter){
-	/*
-		attribute selectors
-	*/
-	var attributeRules = {
-		__proto__: null,
-		equals: function(next, data){
-			var name  = data.name,
-				value = data.value;
+/*
+	attribute selectors
+*/
+var attributeRules = {
+	__proto__: null,
+	equals: function(next, data, options){
+		var name = data.name;
+		var value = data.value;
+		var adapter = options.adapter;
 
-			if(data.ignoreCase){
-				value = value.toLowerCase();
+		if(data.ignoreCase){
+			value = value.toLowerCase();
 
-				return function equalsIC(elem){
-					var attr = adapter.getAttributeValue(elem, name);
-					return attr != null && attr.toLowerCase() === value && next(elem);
-				};
-			}
-
-			return function equals(elem){
-				return adapter.getAttributeValue(elem, name) === value && next(elem);
-			};
-		},
-		hyphen: function(next, data){
-			var name  = data.name,
-				value = data.value,
-				len = value.length;
-
-			if(data.ignoreCase){
-				value = value.toLowerCase();
-
-				return function hyphenIC(elem){
-					var attr = adapter.getAttributeValue(elem, name);
-					return attr != null &&
-							(attr.length === len || attr.charAt(len) === "-") &&
-							attr.substr(0, len).toLowerCase() === value &&
-							next(elem);
-				};
-			}
-
-			return function hyphen(elem){
+			return function equalsIC(elem){
 				var attr = adapter.getAttributeValue(elem, name);
-				return attr != null &&
-						attr.substr(0, len) === value &&
-						(attr.length === len || attr.charAt(len) === "-") &&
-						next(elem);
+				return attr != null && attr.toLowerCase() === value && next(elem);
 			};
-		},
-		element: function(next, data){
-			var name = data.name,
-				value = data.value;
+		}
 
-			if(/\s/.test(value)){
-				return falseFunc;
-			}
+		return function equals(elem){
+			return adapter.getAttributeValue(elem, name) === value && next(elem);
+		};
+	},
+	hyphen: function(next, data, options){
+		var name = data.name;
+		var value = data.value;
+		var len = value.length;
+		var adapter = options.adapter;
 
-			value = value.replace(reChars, "\\$&");
+		if(data.ignoreCase){
+			value = value.toLowerCase();
 
-			var pattern = "(?:^|\\s)" + value + "(?:$|\\s)",
-				flags = data.ignoreCase ? "i" : "",
-				regex = new RegExp(pattern, flags);
+			return function hyphenIC(elem){
+				var attr = adapter.getAttributeValue(elem, name);
+				return (
+					attr != null &&
+					(attr.length === len || attr.charAt(len) === "-") &&
+					attr.substr(0, len).toLowerCase() === value &&
+					next(elem)
+				);
+			};
+		}
 
-			return function element(elem){
+		return function hyphen(elem){
+			var attr = adapter.getAttributeValue(elem, name);
+			return (
+				attr != null &&
+				attr.substr(0, len) === value &&
+				(attr.length === len || attr.charAt(len) === "-") &&
+				next(elem)
+			);
+		};
+	},
+	element: function(next, data, options){
+		var name = data.name;
+		var value = data.value;
+		var adapter = options.adapter;
+
+		if(/\s/.test(value)){
+			return falseFunc;
+		}
+
+		value = value.replace(reChars, "\\$&");
+
+		var pattern = "(?:^|\\s)" + value + "(?:$|\\s)",
+			flags = data.ignoreCase ? "i" : "",
+			regex = new RegExp(pattern, flags);
+
+		return function element(elem){
+			var attr = adapter.getAttributeValue(elem, name);
+			return attr != null && regex.test(attr) && next(elem);
+		};
+	},
+	exists: function(next, data, options){
+		var name = data.name;
+		var adapter = options.adapter;
+
+		return function exists(elem){
+			return adapter.hasAttrib(elem, name) && next(elem);
+		};
+	},
+	start: function(next, data, options){
+		var name = data.name;
+		var value = data.value;
+		var len = value.length;
+		var adapter = options.adapter;
+
+		if(len === 0){
+			return falseFunc;
+		}
+
+		if(data.ignoreCase){
+			value = value.toLowerCase();
+
+			return function startIC(elem){
+				var attr = adapter.getAttributeValue(elem, name);
+				return (
+					attr != null &&
+					attr.substr(0, len).toLowerCase() === value &&
+					next(elem)
+				);
+			};
+		}
+
+		return function start(elem){
+			var attr = adapter.getAttributeValue(elem, name);
+			return attr != null && attr.substr(0, len) === value && next(elem);
+		};
+	},
+	end: function(next, data, options){
+		var name = data.name;
+		var value = data.value;
+		var len = -value.length;
+		var adapter = options.adapter;
+
+		if(len === 0){
+			return falseFunc;
+		}
+
+		if(data.ignoreCase){
+			value = value.toLowerCase();
+
+			return function endIC(elem){
+				var attr = adapter.getAttributeValue(elem, name);
+				return (
+					attr != null && attr.substr(len).toLowerCase() === value && next(elem)
+				);
+			};
+		}
+
+		return function end(elem){
+			var attr = adapter.getAttributeValue(elem, name);
+			return attr != null && attr.substr(len) === value && next(elem);
+		};
+	},
+	any: function(next, data, options){
+		var name = data.name;
+		var value = data.value;
+		var adapter = options.adapter;
+
+		if(value === ""){
+			return falseFunc;
+		}
+
+		if(data.ignoreCase){
+			var regex = new RegExp(value.replace(reChars, "\\$&"), "i");
+
+			return function anyIC(elem){
 				var attr = adapter.getAttributeValue(elem, name);
 				return attr != null && regex.test(attr) && next(elem);
 			};
-		},
-		exists: function(next, data){
-			var name = data.name;
-			return function exists(elem){
-				return adapter.hasAttrib(elem, name) && next(elem);
+		}
+
+		return function any(elem){
+			var attr = adapter.getAttributeValue(elem, name);
+			return attr != null && attr.indexOf(value) >= 0 && next(elem);
+		};
+	},
+	not: function(next, data, options){
+		var name = data.name;
+		var value = data.value;
+		var adapter = options.adapter;
+
+		if(value === ""){
+			return function notEmpty(elem){
+				return !!adapter.getAttributeValue(elem, name) && next(elem);
 			};
-		},
-		start: function(next, data){
-			var name  = data.name,
-				value = data.value,
-				len = value.length;
+		} else if(data.ignoreCase){
+			value = value.toLowerCase();
 
-			if(len === 0){
-				return falseFunc;
-			}
-
-			if(data.ignoreCase){
-				value = value.toLowerCase();
-
-				return function startIC(elem){
-					var attr = adapter.getAttributeValue(elem, name);
-					return attr != null && attr.substr(0, len).toLowerCase() === value && next(elem);
-				};
-			}
-
-			return function start(elem){
+			return function notIC(elem){
 				var attr = adapter.getAttributeValue(elem, name);
-				return attr != null && attr.substr(0, len) === value && next(elem);
-			};
-		},
-		end: function(next, data){
-			var name  = data.name,
-				value = data.value,
-				len   = -value.length;
-
-			if(len === 0){
-				return falseFunc;
-			}
-
-			if(data.ignoreCase){
-				value = value.toLowerCase();
-
-				return function endIC(elem){
-					var attr = adapter.getAttributeValue(elem, name);
-					return attr != null && attr.substr(len).toLowerCase() === value && next(elem);
-				};
-			}
-
-			return function end(elem){
-				var attr = adapter.getAttributeValue(elem, name);
-				return attr != null && attr.substr(len) === value && next(elem);
-			};
-		},
-		any: function(next, data){
-			var name  = data.name,
-				value = data.value;
-
-			if(value === ""){
-				return falseFunc;
-			}
-
-			if(data.ignoreCase){
-				var regex = new RegExp(value.replace(reChars, "\\$&"), "i");
-
-				return function anyIC(elem){
-					var attr = adapter.getAttributeValue(elem, name);
-					return attr != null && regex.test(attr) && next(elem);
-				};
-			}
-
-			return function any(elem){
-				var attr = adapter.getAttributeValue(elem, name);
-				return attr != null && attr.indexOf(value) >= 0 && next(elem);
-			};
-		},
-		not: function(next, data){
-			var name  = data.name,
-				value = data.value;
-
-			if(value === ""){
-				return function notEmpty(elem){
-					return !!adapter.getAttributeValue(elem, name) && next(elem);
-				};
-			} else if(data.ignoreCase){
-				value = value.toLowerCase();
-
-				return function notIC(elem){
-					var attr = adapter.getAttributeValue(elem, name);
-					return attr != null && attr.toLowerCase() !== value && next(elem);
-				};
-			}
-
-			return function not(elem){
-				return adapter.getAttributeValue(elem, name) !== value && next(elem);
+				return attr != null && attr.toLowerCase() !== value && next(elem);
 			};
 		}
-	};
 
-	return {
-		compile: function(next, data, options){
-			if(options && options.strict && (
-				data.ignoreCase || data.action === "not"
-			)) throw new Error("Unsupported attribute selector");
-			return attributeRules[data.action](next, data);
-		},
-		rules: attributeRules
-	};
-}
+		return function not(elem){
+			return adapter.getAttributeValue(elem, name) !== value && next(elem);
+		};
+	}
+};
 
-module.exports = factory;
+module.exports = {
+	compile: function(next, data, options){
+		if(
+			options &&
+			options.strict &&
+			(data.ignoreCase || data.action === "not")
+		){
+			throw new Error("Unsupported attribute selector");
+		}
+		return attributeRules[data.action](next, data, options);
+	},
+	rules: attributeRules
+};

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -2,206 +2,219 @@
 	compiles a selector to an executable function
 */
 
-module.exports = compileFactory;
+module.exports = compile;
 
-var parse          = require("css-what"),
-	BaseFuncs      = require("boolbase"),
-	sortRules      = require("./sort.js"),
-	procedure      = require("./procedure.json"),
-	rulesFactory   = require("./general.js"),
-	pseudosFactory = require("./pseudos.js"),
-	trueFunc       = BaseFuncs.trueFunc,
-	falseFunc      = BaseFuncs.falseFunc;
+var parse = require("css-what");
+var BaseFuncs = require("boolbase");
+var sortRules = require("./sort.js");
+var procedure = require("./procedure.json");
+var Rules = require("./general.js");
+var Pseudos = require("./pseudos.js");
+var trueFunc = BaseFuncs.trueFunc;
+var falseFunc = BaseFuncs.falseFunc;
 
-function compileFactory(adapter){
-	var Pseudos     = pseudosFactory(adapter),
-		filters     = Pseudos.filters,
-		Rules 			= rulesFactory(adapter, Pseudos);
+var filters = Pseudos.filters;
 
-	function compile(selector, options, context){
-		var next = compileUnsafe(selector, options, context);
-		return wrap(next);
-	}
+function compile(selector, options, context){
+	var next = compileUnsafe(selector, options, context);
+	return wrap(next, options);
+}
 
-	function wrap(next){
-		return function base(elem){
-			return adapter.isTag(elem) && next(elem);
-		};
-	}
+function wrap(next, options){
+	var adapter = options.adapter;
 
-	function compileUnsafe(selector, options, context){
-		var token = parse(selector, options);
-		return compileToken(token, options, context);
-	}
+	return function base(elem){
+		return adapter.isTag(elem) && next(elem);
+	};
+}
 
-	function includesScopePseudo(t){
-		return t.type === "pseudo" && (
-			t.name === "scope" || (
-				Array.isArray(t.data) &&
+function compileUnsafe(selector, options, context){
+	var token = parse(selector, options);
+	return compileToken(token, options, context);
+}
+
+function includesScopePseudo(t){
+	return (
+		t.type === "pseudo" &&
+		(t.name === "scope" ||
+			(Array.isArray(t.data) &&
 				t.data.some(function(data){
 					return data.some(includesScopePseudo);
-				})
-			)
-		);
-	}
+				})))
+	);
+}
 
-	var DESCENDANT_TOKEN = {type: "descendant"},
-		FLEXIBLE_DESCENDANT_TOKEN = {type: "_flexibleDescendant"},
-		SCOPE_TOKEN = {type: "pseudo", name: "scope"},
-		PLACEHOLDER_ELEMENT = {};
+var DESCENDANT_TOKEN = { type: "descendant" };
+var FLEXIBLE_DESCENDANT_TOKEN = { type: "_flexibleDescendant" };
+var SCOPE_TOKEN = { type: "pseudo", name: "scope" };
+var PLACEHOLDER_ELEMENT = {};
 
-	//CSS 4 Spec (Draft): 3.3.1. Absolutizing a Scope-relative Selector
-	//http://www.w3.org/TR/selectors4/#absolutizing
-	function absolutize(token, context){
-		//TODO better check if context is document
-		var hasContext = !!context && !!context.length && context.every(function(e){
+//CSS 4 Spec (Draft): 3.3.1. Absolutizing a Scope-relative Selector
+//http://www.w3.org/TR/selectors4/#absolutizing
+function absolutize(token, options, context){
+	var adapter = options.adapter;
+
+	//TODO better check if context is document
+	var hasContext =
+		!!context &&
+		!!context.length &&
+		context.every(function(e){
 			return e === PLACEHOLDER_ELEMENT || !!adapter.getParent(e);
 		});
 
-
-		token.forEach(function(t){
-			if(t.length > 0 && isTraversal(t[0]) && t[0].type !== "descendant"){
-				//don't return in else branch
-			} else if(hasContext && !includesScopePseudo(t)){
-				t.unshift(DESCENDANT_TOKEN);
-			} else {
-				return;
-			}
-
-			t.unshift(SCOPE_TOKEN);
-		});
-	}
-
-	function compileToken(token, options, context){
-		token = token.filter(function(t){ return t.length > 0; });
-
-		token.forEach(sortRules);
-
-		var isArrayContext = Array.isArray(context);
-
-		context = (options && options.context) || context;
-
-		if(context && !isArrayContext) context = [context];
-
-		absolutize(token, context);
-
-		var shouldTestNextSiblings = false;
-
-		var query = token
-			.map(function(rules){
-				if(rules[0] && rules[1] && rules[0].name === "scope"){
-					var ruleType = rules[1].type;
-					if(isArrayContext && ruleType === "descendant") rules[1] = FLEXIBLE_DESCENDANT_TOKEN;
-					else if(ruleType === "adjacent" || ruleType === "sibling") shouldTestNextSiblings = true;
-				}
-				return compileRules(rules, options, context);
-			})
-			.reduce(reduceRules, falseFunc);
-
-		query.shouldTestNextSiblings = shouldTestNextSiblings;
-
-		return query;
-	}
-
-	function isTraversal(t){
-		return procedure[t.type] < 0;
-	}
-
-	function compileRules(rules, options, context){
-		return rules.reduce(function(func, rule){
-			if(func === falseFunc) return func;
-			return Rules[rule.type](func, rule, options, context);
-		}, options && options.rootFunc || trueFunc);
-	}
-
-	function reduceRules(a, b){
-		if(b === falseFunc || a === trueFunc){
-			return a;
-		}
-		if(a === falseFunc || b === trueFunc){
-			return b;
+	token.forEach(function(t){
+		if(t.length > 0 && isTraversal(t[0]) && t[0].type !== "descendant"){
+			//don't return in else branch
+		} else if(hasContext && !includesScopePseudo(t)){
+			t.unshift(DESCENDANT_TOKEN);
+		} else {
+			return;
 		}
 
-		return function combine(elem){
-			return a(elem) || b(elem);
-		};
-	}
-
-	function containsTraversal(t){
-		return t.some(isTraversal);
-	}
-
-	//:not, :has and :matches have to compile selectors
-	//doing this in lib/pseudos.js would lead to circular dependencies,
-	//so we add them here
-	filters.not = function(next, token, options, context){
-		var opts = {
-			xmlMode: !!(options && options.xmlMode),
-			strict: !!(options && options.strict)
-		};
-
-		if(opts.strict){
-			if(token.length > 1 || token.some(containsTraversal)){
-				throw new Error("complex selectors in :not aren't allowed in strict mode");
-			}
-		}
-
-		var func = compileToken(token, opts, context);
-
-		if(func === falseFunc) return next;
-		if(func === trueFunc)  return falseFunc;
-
-		return function(elem){
-			return !func(elem) && next(elem);
-		};
-	};
-
-	filters.has = function(next, token, options){
-		var opts = {
-			xmlMode: !!(options && options.xmlMode),
-			strict: !!(options && options.strict)
-		};
-
-		//FIXME: Uses an array as a pointer to the current element (side effects)
-		var context = token.some(containsTraversal) ? [PLACEHOLDER_ELEMENT] : null;
-
-		var func = compileToken(token, opts, context);
-
-		if(func === falseFunc) return falseFunc;
-		if(func === trueFunc){
-			return function(elem){
-				return adapter.getChildren(elem).some(adapter.isTag) && next(elem);
-			};
-		}
-
-		func = wrap(func);
-
-		if(context){
-			return function has(elem){
-				return next(elem) && (
-					(context[0] = elem), adapter.existsOne(func, adapter.getChildren(elem))
-				);
-			};
-		}
-
-		return function has(elem){
-			return next(elem) && adapter.existsOne(func, adapter.getChildren(elem));
-		};
-	};
-
-	filters.matches = function(next, token, options, context){
-		var opts = {
-			xmlMode: !!(options && options.xmlMode),
-			strict: !!(options && options.strict),
-			rootFunc: next
-		};
-
-		return compileToken(token, opts, context);
-	};
-
-	compile.compileToken = compileToken;
-	compile.compileUnsafe = compileUnsafe;
-	compile.Pseudos = Pseudos;
-
-	return compile;
+		t.unshift(SCOPE_TOKEN);
+	});
 }
+
+function compileToken(token, options, context){
+	token = token.filter(function(t){
+		return t.length > 0;
+	});
+
+	token.forEach(sortRules);
+
+	var isArrayContext = Array.isArray(context);
+
+	context = (options && options.context) || context;
+
+	if(context && !isArrayContext) context = [context];
+
+	absolutize(token, options, context);
+
+	var shouldTestNextSiblings = false;
+
+	var query = token
+		.map(function(rules){
+			if(rules[0] && rules[1] && rules[0].name === "scope"){
+				var ruleType = rules[1].type;
+				if(isArrayContext && ruleType === "descendant"){
+					rules[1] = FLEXIBLE_DESCENDANT_TOKEN;
+				} else if(ruleType === "adjacent" || ruleType === "sibling"){
+					shouldTestNextSiblings = true;
+				}
+			}
+			return compileRules(rules, options, context);
+		})
+		.reduce(reduceRules, falseFunc);
+
+	query.shouldTestNextSiblings = shouldTestNextSiblings;
+
+	return query;
+}
+
+function isTraversal(t){
+	return procedure[t.type] < 0;
+}
+
+function compileRules(rules, options, context){
+	return rules.reduce(function(func, rule){
+		if(func === falseFunc) return func;
+		return Rules[rule.type](func, rule, options, context);
+	}, (options && options.rootFunc) || trueFunc);
+}
+
+function reduceRules(a, b){
+	if(b === falseFunc || a === trueFunc){
+		return a;
+	}
+	if(a === falseFunc || b === trueFunc){
+		return b;
+	}
+
+	return function combine(elem){
+		return a(elem) || b(elem);
+	};
+}
+
+function containsTraversal(t){
+	return t.some(isTraversal);
+}
+
+//:not, :has and :matches have to compile selectors
+//doing this in lib/pseudos.js would lead to circular dependencies,
+//so we add them here
+filters.not = function(next, token, options, context){
+	var opts = {
+		xmlMode: !!(options && options.xmlMode),
+		strict: !!(options && options.strict),
+		adapter: options.adapter
+	};
+
+	if(opts.strict){
+		if(token.length > 1 || token.some(containsTraversal)){
+			throw new Error(
+				"complex selectors in :not aren't allowed in strict mode"
+			);
+		}
+	}
+
+	var func = compileToken(token, opts, context);
+
+	if(func === falseFunc) return next;
+	if(func === trueFunc) return falseFunc;
+
+	return function not(elem){
+		return !func(elem) && next(elem);
+	};
+};
+
+filters.has = function(next, token, options){
+	var adapter = options.adapter;
+	var opts = {
+		xmlMode: !!(options && options.xmlMode),
+		strict: !!(options && options.strict),
+		adapter: adapter
+	};
+
+	//FIXME: Uses an array as a pointer to the current element (side effects)
+	var context = token.some(containsTraversal) ? [PLACEHOLDER_ELEMENT] : null;
+
+	var func = compileToken(token, opts, context);
+
+	if(func === falseFunc) return falseFunc;
+	if(func === trueFunc){
+		return function hasChild(elem){
+			return adapter.getChildren(elem).some(adapter.isTag) && next(elem);
+		};
+	}
+
+	func = wrap(func, options);
+
+	if(context){
+		return function has(elem){
+			return (
+				next(elem) &&
+				((context[0] = elem),
+					adapter.existsOne(func, adapter.getChildren(elem)))
+			);
+		};
+	}
+
+	return function has(elem){
+		return next(elem) && adapter.existsOne(func, adapter.getChildren(elem));
+	};
+};
+
+filters.matches = function(next, token, options, context){
+	var opts = {
+		xmlMode: !!(options && options.xmlMode),
+		strict: !!(options && options.strict),
+		rootFunc: next,
+		adapter: options.adapter
+	};
+
+	return compileToken(token, opts, context);
+};
+
+compile.compileToken = compileToken;
+compile.compileUnsafe = compileUnsafe;
+compile.Pseudos = Pseudos;

--- a/lib/general.js
+++ b/lib/general.js
@@ -41,7 +41,6 @@ function generalFactory(adapter, Pseudos){
 		_flexibleDescendant: function(next){
 			// Include element itself, only used while querying an array
 			return function descendant(elem){
-
 				var found = next(elem);
 
 				while(!found && (elem = adapter.getParent(elem))){
@@ -52,7 +51,9 @@ function generalFactory(adapter, Pseudos){
 			};
 		},
 		parent: function(next, data, options){
-			if(options && options.strict) throw new Error("Parent selector isn't part of CSS3");
+			if(options && options.strict){
+				throw new Error("Parent selector isn't part of CSS3");
+			}
 
 			return function parent(elem){
 				return adapter.getChildren(elem).some(test);

--- a/lib/general.js
+++ b/lib/general.js
@@ -41,6 +41,7 @@ function generalFactory(adapter, Pseudos){
 		_flexibleDescendant: function(next){
 			// Include element itself, only used while querying an array
 			return function descendant(elem){
+
 				var found = next(elem);
 
 				while(!found && (elem = adapter.getParent(elem))){
@@ -51,9 +52,7 @@ function generalFactory(adapter, Pseudos){
 			};
 		},
 		parent: function(next, data, options){
-			if(options && options.strict){
-				throw new Error("Parent selector isn't part of CSS3");
-			}
+			if(options && options.strict) throw new Error("Parent selector isn't part of CSS3");
 
 			return function parent(elem){
 				return adapter.getChildren(elem).some(test);

--- a/lib/general.js
+++ b/lib/general.js
@@ -1,107 +1,117 @@
-var attributeFactory = require("./attributes.js");
+var attributes = require("./attributes.js");
+var Pseudos = require("./pseudos");
 
-function generalFactory(adapter, Pseudos){
-	/*
-		all available rules
-	*/
-	return {
-		__proto__: null,
+/*
+	all available rules
+*/
+module.exports = {
+	__proto__: null,
 
-		attribute: attributeFactory(adapter).compile,
-		pseudo: Pseudos.compile,
+	attribute: attributes.compile,
+	pseudo: Pseudos.compile,
 
-		//tags
-		tag: function(next, data){
-			var name = data.name;
-			return function tag(elem){
-				return adapter.getName(elem) === name && next(elem);
-			};
-		},
+	//tags
+	tag: function(next, data, options){
+		var name = data.name;
+		var adapter = options.adapter;
 
-		//traversal
-		descendant: function(next){
-			// eslint-disable-next-line no-undef
-			var isFalseCache = typeof WeakSet !== "undefined" ? new WeakSet() : null;
+		return function tag(elem){
+			return adapter.getName(elem) === name && next(elem);
+		};
+	},
 
-			return function descendant(elem){
-				var found = false;
+	//traversal
+	descendant: function(next, data, options){
+		// eslint-disable-next-line no-undef
+		var isFalseCache = typeof WeakSet !== "undefined" ? new WeakSet() : null;
+		var adapter = options.adapter;
 
-				while(!found && (elem = adapter.getParent(elem))){
-					if(!isFalseCache || !isFalseCache.has(elem)){
-						found = next(elem);
-						if(!found && isFalseCache){
-							isFalseCache.add(elem);
-						}
-					}
-				}
+		return function descendant(elem){
+			var found = false;
 
-				return found;
-			};
-		},
-		_flexibleDescendant: function(next){
-			// Include element itself, only used while querying an array
-			return function descendant(elem){
-				var found = next(elem);
-
-				while(!found && (elem = adapter.getParent(elem))){
+			while(!found && (elem = adapter.getParent(elem))){
+				if(!isFalseCache || !isFalseCache.has(elem)){
 					found = next(elem);
-				}
-
-				return found;
-			};
-		},
-		parent: function(next, data, options){
-			if(options && options.strict){
-				throw new Error("Parent selector isn't part of CSS3");
-			}
-
-			return function parent(elem){
-				return adapter.getChildren(elem).some(test);
-			};
-
-			function test(elem){
-				return adapter.isTag(elem) && next(elem);
-			}
-		},
-		child: function(next){
-			return function child(elem){
-				var parent = adapter.getParent(elem);
-				return !!parent && next(parent);
-			};
-		},
-		sibling: function(next){
-			return function sibling(elem){
-				var siblings = adapter.getSiblings(elem);
-
-				for(var i = 0; i < siblings.length; i++){
-					if(adapter.isTag(siblings[i])){
-						if(siblings[i] === elem) break;
-						if(next(siblings[i])) return true;
+					if(!found && isFalseCache){
+						isFalseCache.add(elem);
 					}
 				}
+			}
 
-				return false;
-			};
-		},
-		adjacent: function(next){
-			return function adjacent(elem){
-				var siblings = adapter.getSiblings(elem),
-					lastElement;
+			return found;
+		};
+	},
+	_flexibleDescendant: function(next, data, options){
+		var adapter = options.adapter;
 
-				for(var i = 0; i < siblings.length; i++){
-					if(adapter.isTag(siblings[i])){
-						if(siblings[i] === elem) break;
-						lastElement = siblings[i];
-					}
-				}
+		// Include element itself, only used while querying an array
+		return function descendant(elem){
+			var found = next(elem);
 
-				return !!lastElement && next(lastElement);
-			};
-		},
-		universal: function(next){
-			return next;
+			while(!found && (elem = adapter.getParent(elem))){
+				found = next(elem);
+			}
+
+			return found;
+		};
+	},
+	parent: function(next, data, options){
+		if(options && options.strict){
+			throw new Error("Parent selector isn't part of CSS3");
 		}
-	};
-}
 
-module.exports = generalFactory;
+		var adapter = options.adapter;
+
+		return function parent(elem){
+			return adapter.getChildren(elem).some(test);
+		};
+
+		function test(elem){
+			return adapter.isTag(elem) && next(elem);
+		}
+	},
+	child: function(next, data, options){
+		var adapter = options.adapter;
+
+		return function child(elem){
+			var parent = adapter.getParent(elem);
+			return !!parent && next(parent);
+		};
+	},
+	sibling: function(next, data, options){
+		var adapter = options.adapter;
+
+		return function sibling(elem){
+			var siblings = adapter.getSiblings(elem);
+
+			for(var i = 0; i < siblings.length; i++){
+				if(adapter.isTag(siblings[i])){
+					if(siblings[i] === elem) break;
+					if(next(siblings[i])) return true;
+				}
+			}
+
+			return false;
+		};
+	},
+	adjacent: function(next, data, options){
+		var adapter = options.adapter;
+
+		return function adjacent(elem){
+			var siblings = adapter.getSiblings(elem),
+				lastElement;
+
+			for(var i = 0; i < siblings.length; i++){
+				if(adapter.isTag(siblings[i])){
+					if(siblings[i] === elem) break;
+					lastElement = siblings[i];
+				}
+			}
+
+			return !!lastElement && next(lastElement);
+		};
+	},
+	universal: function(next){
+		return next;
+	}
+};

--- a/lib/procedure.json
+++ b/lib/procedure.json
@@ -1,11 +1,11 @@
 {
-  "universal": 50,
-  "tag": 30,
-  "attribute": 1,
-  "pseudo": 0,
-  "descendant": -1,
-  "child": -1,
-  "parent": -1,
-  "sibling": -1,
-  "adjacent": -1
+	"universal": 50,
+	"tag": 30,
+	"attribute": 1,
+	"pseudo": 0,
+	"descendant": -1,
+	"child": -1,
+	"parent": -1,
+	"sibling": -1,
+	"adjacent": -1
 }

--- a/lib/pseudos.js
+++ b/lib/pseudos.js
@@ -11,359 +11,378 @@
 	  they need to return a boolean
 */
 
-var getNCheck         = require("nth-check"),
-	BaseFuncs         = require("boolbase"),
-	attributesFactory = require("./attributes.js"),
-	trueFunc          = BaseFuncs.trueFunc,
-	falseFunc         = BaseFuncs.falseFunc;
+var getNCheck = require("nth-check");
+var BaseFuncs = require("boolbase");
+var attributes = require("./attributes.js");
+var trueFunc = BaseFuncs.trueFunc;
+var falseFunc = BaseFuncs.falseFunc;
 
-function filtersFactory(adapter){
-	var attributes  = attributesFactory(adapter),
-		checkAttrib = attributes.rules.equals;
+var checkAttrib = attributes.rules.equals;
 
-	//helper methods
-	function equals(a, b){
-		if(typeof adapter.equals === "function") return adapter.equals(a, b);
-
-		return a === b;
-	}
-
-	function getAttribFunc(name, value){
-		var data = {name: name, value: value};
-		return function attribFunc(next){
-			return checkAttrib(next, data);
-		};
-	}
-
-	function getChildFunc(next){
-		return function(elem){
-			return !!adapter.getParent(elem) && next(elem);
-		};
-	}
-
-	var filters = {
-		contains: function(next, text){
-			return function contains(elem){
-				return next(elem) && adapter.getText(elem).indexOf(text) >= 0;
-			};
-		},
-		icontains: function(next, text){
-			var itext = text.toLowerCase();
-			return function icontains(elem){
-				return next(elem) &&
-					adapter.getText(elem).toLowerCase().indexOf(itext) >= 0;
-			};
-		},
-
-		//location specific methods
-		"nth-child": function(next, rule){
-			var func = getNCheck(rule);
-
-			if(func === falseFunc) return func;
-			if(func === trueFunc)  return getChildFunc(next);
-
-			return function nthChild(elem){
-				var siblings = adapter.getSiblings(elem);
-
-				for(var i = 0, pos = 0; i < siblings.length; i++){
-					if(adapter.isTag(siblings[i])){
-						if(siblings[i] === elem) break;
-						else pos++;
-					}
-				}
-
-				return func(pos) && next(elem);
-			};
-		},
-		"nth-last-child": function(next, rule){
-			var func = getNCheck(rule);
-
-			if(func === falseFunc) return func;
-			if(func === trueFunc)  return getChildFunc(next);
-
-			return function nthLastChild(elem){
-				var siblings = adapter.getSiblings(elem);
-
-				for(var pos = 0, i = siblings.length - 1; i >= 0; i--){
-					if(adapter.isTag(siblings[i])){
-						if(siblings[i] === elem) break;
-						else pos++;
-					}
-				}
-
-				return func(pos) && next(elem);
-			};
-		},
-		"nth-of-type": function(next, rule){
-			var func = getNCheck(rule);
-
-			if(func === falseFunc) return func;
-			if(func === trueFunc)  return getChildFunc(next);
-
-			return function nthOfType(elem){
-				var siblings = adapter.getSiblings(elem);
-
-				for(var pos = 0, i = 0; i < siblings.length; i++){
-					if(adapter.isTag(siblings[i])){
-						if(siblings[i] === elem) break;
-						if(adapter.getName(siblings[i]) === adapter.getName(elem)) pos++;
-					}
-				}
-
-				return func(pos) && next(elem);
-			};
-		},
-		"nth-last-of-type": function(next, rule){
-			var func = getNCheck(rule);
-
-			if(func === falseFunc) return func;
-			if(func === trueFunc)  return getChildFunc(next);
-
-			return function nthLastOfType(elem){
-				var siblings = adapter.getSiblings(elem);
-
-				for(var pos = 0, i = siblings.length - 1; i >= 0; i--){
-					if(adapter.isTag(siblings[i])){
-						if(siblings[i] === elem) break;
-						if(adapter.getName(siblings[i]) === adapter.getName(elem)) pos++;
-					}
-				}
-
-				return func(pos) && next(elem);
-			};
-		},
-
-		//TODO determine the actual root element
-		root: function(next){
-			return function(elem){
-				return !adapter.getParent(elem) && next(elem);
-			};
-		},
-
-		scope: function(next, rule, options, context){
-			if(!context || context.length === 0){
-				//equivalent to :root
-				return filters.root(next);
-			}
-
-			if(context.length === 1){
-				//NOTE: can't be unpacked, as :has uses this for side-effects
-				return function(elem){
-					return equals(context[0], elem) && next(elem);
-				};
-			}
-
-			return function(elem){
-				return context.indexOf(elem) >= 0 && next(elem);
-			};
-		},
-
-		//jQuery extensions (others follow as pseudos)
-		checkbox: getAttribFunc("type", "checkbox"),
-		file: getAttribFunc("type", "file"),
-		password: getAttribFunc("type", "password"),
-		radio: getAttribFunc("type", "radio"),
-		reset: getAttribFunc("type", "reset"),
-		image: getAttribFunc("type", "image"),
-		submit: getAttribFunc("type", "submit")
+function getAttribFunc(name, value){
+	var data = { name: name, value: value };
+	return function attribFunc(next, rule, options){
+		return checkAttrib(next, data, options);
 	};
-	return filters;
 }
 
-function pseudosFactory(adapter){
-	//helper methods
-	function getFirstElement(elems){
-		for(var i = 0; elems && i < elems.length; i++){
-			if(adapter.isTag(elems[i])) return elems[i];
+function getChildFunc(next, adapter){
+	return function(elem){
+		return !!adapter.getParent(elem) && next(elem);
+	};
+}
+
+var filters = {
+	contains: function(next, text, options){
+		var adapter = options.adapter;
+
+		return function contains(elem){
+			return next(elem) && adapter.getText(elem).indexOf(text) >= 0;
+		};
+	},
+	icontains: function(next, text, options){
+		var itext = text.toLowerCase();
+		var adapter = options.adapter;
+
+		return function icontains(elem){
+			return (
+				next(elem) &&
+				adapter
+					.getText(elem)
+					.toLowerCase()
+					.indexOf(itext) >= 0
+			);
+		};
+	},
+
+	//location specific methods
+	"nth-child": function(next, rule, options){
+		var func = getNCheck(rule);
+		var adapter = options.adapter;
+
+		if(func === falseFunc) return func;
+		if(func === trueFunc) return getChildFunc(next, adapter);
+
+		return function nthChild(elem){
+			var siblings = adapter.getSiblings(elem);
+
+			for(var i = 0, pos = 0; i < siblings.length; i++){
+				if(adapter.isTag(siblings[i])){
+					if(siblings[i] === elem) break;
+					else pos++;
+				}
+			}
+
+			return func(pos) && next(elem);
+		};
+	},
+	"nth-last-child": function(next, rule, options){
+		var func = getNCheck(rule);
+		var adapter = options.adapter;
+
+		if(func === falseFunc) return func;
+		if(func === trueFunc) return getChildFunc(next, adapter);
+
+		return function nthLastChild(elem){
+			var siblings = adapter.getSiblings(elem);
+
+			for(var pos = 0, i = siblings.length - 1; i >= 0; i--){
+				if(adapter.isTag(siblings[i])){
+					if(siblings[i] === elem) break;
+					else pos++;
+				}
+			}
+
+			return func(pos) && next(elem);
+		};
+	},
+	"nth-of-type": function(next, rule, options){
+		var func = getNCheck(rule);
+		var adapter = options.adapter;
+
+		if(func === falseFunc) return func;
+		if(func === trueFunc) return getChildFunc(next, adapter);
+
+		return function nthOfType(elem){
+			var siblings = adapter.getSiblings(elem);
+
+			for(var pos = 0, i = 0; i < siblings.length; i++){
+				if(adapter.isTag(siblings[i])){
+					if(siblings[i] === elem) break;
+					if(adapter.getName(siblings[i]) === adapter.getName(elem)) pos++;
+				}
+			}
+
+			return func(pos) && next(elem);
+		};
+	},
+	"nth-last-of-type": function(next, rule, options){
+		var func = getNCheck(rule);
+		var adapter = options.adapter;
+
+		if(func === falseFunc) return func;
+		if(func === trueFunc) return getChildFunc(next, adapter);
+
+		return function nthLastOfType(elem){
+			var siblings = adapter.getSiblings(elem);
+
+			for(var pos = 0, i = siblings.length - 1; i >= 0; i--){
+				if(adapter.isTag(siblings[i])){
+					if(siblings[i] === elem) break;
+					if(adapter.getName(siblings[i]) === adapter.getName(elem)) pos++;
+				}
+			}
+
+			return func(pos) && next(elem);
+		};
+	},
+
+	//TODO determine the actual root element
+	root: function(next, rule, options){
+		var adapter = options.adapter;
+
+		return function(elem){
+			return !adapter.getParent(elem) && next(elem);
+		};
+	},
+
+	scope: function(next, rule, options, context){
+		var adapter = options.adapter;
+
+		if(!context || context.length === 0){
+			//equivalent to :root
+			return filters.root(next, rule, options);
 		}
+
+		function equals(a, b){
+			if(typeof adapter.equals === "function") return adapter.equals(a, b);
+
+			return a === b;
+		}
+
+		if(context.length === 1){
+			//NOTE: can't be unpacked, as :has uses this for side-effects
+			return function(elem){
+				return equals(context[0], elem) && next(elem);
+			};
+		}
+
+		return function(elem){
+			return context.indexOf(elem) >= 0 && next(elem);
+		};
+	},
+
+	//jQuery extensions (others follow as pseudos)
+	checkbox: getAttribFunc("type", "checkbox"),
+	file: getAttribFunc("type", "file"),
+	password: getAttribFunc("type", "password"),
+	radio: getAttribFunc("type", "radio"),
+	reset: getAttribFunc("type", "reset"),
+	image: getAttribFunc("type", "image"),
+	submit: getAttribFunc("type", "submit")
+};
+
+//helper methods
+function getFirstElement(elems, adapter){
+	for(var i = 0; elems && i < elems.length; i++){
+		if(adapter.isTag(elems[i])) return elems[i];
+	}
+}
+
+//while filters are precompiled, pseudos get called when they are needed
+var pseudos = {
+	empty: function(elem, adapter){
+		return !adapter.getChildren(elem).some(function(elem){
+			return adapter.isTag(elem) || elem.type === "text";
+		});
+	},
+
+	"first-child": function(elem, adapter){
+		return getFirstElement(adapter.getSiblings(elem), adapter) === elem;
+	},
+	"last-child": function(elem, adapter){
+		var siblings = adapter.getSiblings(elem);
+
+		for(var i = siblings.length - 1; i >= 0; i--){
+			if(siblings[i] === elem) return true;
+			if(adapter.isTag(siblings[i])) break;
+		}
+
+		return false;
+	},
+	"first-of-type": function(elem, adapter){
+		var siblings = adapter.getSiblings(elem);
+
+		for(var i = 0; i < siblings.length; i++){
+			if(adapter.isTag(siblings[i])){
+				if(siblings[i] === elem) return true;
+				if(adapter.getName(siblings[i]) === adapter.getName(elem)) break;
+			}
+		}
+
+		return false;
+	},
+	"last-of-type": function(elem, adapter){
+		var siblings = adapter.getSiblings(elem);
+
+		for(var i = siblings.length - 1; i >= 0; i--){
+			if(adapter.isTag(siblings[i])){
+				if(siblings[i] === elem) return true;
+				if(adapter.getName(siblings[i]) === adapter.getName(elem)) break;
+			}
+		}
+
+		return false;
+	},
+	"only-of-type": function(elem, adapter){
+		var siblings = adapter.getSiblings(elem);
+
+		for(var i = 0, j = siblings.length; i < j; i++){
+			if(adapter.isTag(siblings[i])){
+				if(siblings[i] === elem) continue;
+				if(adapter.getName(siblings[i]) === adapter.getName(elem)){
+					return false;
+				}
+			}
+		}
+
+		return true;
+	},
+	"only-child": function(elem, adapter){
+		var siblings = adapter.getSiblings(elem);
+
+		for(var i = 0; i < siblings.length; i++){
+			if(adapter.isTag(siblings[i]) && siblings[i] !== elem) return false;
+		}
+
+		return true;
+	},
+
+	//:matches(a, area, link)[href]
+	link: function(elem, adapter){
+		return adapter.hasAttrib(elem, "href");
+	},
+	visited: falseFunc, //Valid implementation
+	//TODO: :any-link once the name is finalized (as an alias of :link)
+
+	//forms
+	//to consider: :target
+
+	//:matches([selected], select:not([multiple]):not(> option[selected]) > option:first-of-type)
+	selected: function(elem, adapter){
+		if(adapter.hasAttrib(elem, "selected")) return true;
+		else if(adapter.getName(elem) !== "option") return false;
+
+		//the first <option> in a <select> is also selected
+		var parent = adapter.getParent(elem);
+
+		if(
+			!parent ||
+			adapter.getName(parent) !== "select" ||
+			adapter.hasAttrib(parent, "multiple")
+		){
+			return false;
+		}
+
+		var siblings = adapter.getChildren(parent);
+		var sawElem = false;
+
+		for(var i = 0; i < siblings.length; i++){
+			if(adapter.isTag(siblings[i])){
+				if(siblings[i] === elem){
+					sawElem = true;
+				} else if(!sawElem){
+					return false;
+				} else if(adapter.hasAttrib(siblings[i], "selected")){
+					return false;
+				}
+			}
+		}
+
+		return sawElem;
+	},
+	//https://html.spec.whatwg.org/multipage/scripting.html#disabled-elements
+	//:matches(
+	//  :matches(button, input, select, textarea, menuitem, optgroup, option)[disabled],
+	//  optgroup[disabled] > option),
+	// fieldset[disabled] * //TODO not child of first <legend>
+	//)
+	disabled: function(elem, adapter){
+		return adapter.hasAttrib(elem, "disabled");
+	},
+	enabled: function(elem, adapter){
+		return !adapter.hasAttrib(elem, "disabled");
+	},
+	//:matches(:matches(:radio, :checkbox)[checked], :selected) (TODO menuitem)
+	checked: function(elem, adapter){
+		return (
+			adapter.hasAttrib(elem, "checked") || pseudos.selected(elem, adapter)
+		);
+	},
+	//:matches(input, select, textarea)[required]
+	required: function(elem, adapter){
+		return adapter.hasAttrib(elem, "required");
+	},
+	//:matches(input, select, textarea):not([required])
+	optional: function(elem, adapter){
+		return !adapter.hasAttrib(elem, "required");
+	},
+
+	//jQuery extensions
+
+	//:not(:empty)
+	parent: function(elem, adapter){
+		return !pseudos.empty(elem, adapter);
+	},
+	//:matches(h1, h2, h3, h4, h5, h6)
+	header: namePseudo(["h1", "h2", "h3", "h4", "h5", "h6"]),
+
+	//:matches(button, input[type=button])
+	button: function(elem, adapter){
+		var name = adapter.getName(elem);
+		return (
+			name === "button" ||
+			(name === "input" && adapter.getAttributeValue(elem, "type") === "button")
+		);
+	},
+	//:matches(input, textarea, select, button)
+	input: namePseudo(["input", "textarea", "select", "button"]),
+	//input:matches(:not([type!='']), [type='text' i])
+	text: function(elem, adapter){
+		var attr;
+		return (
+			adapter.getName(elem) === "input" &&
+			(!(attr = adapter.getAttributeValue(elem, "type")) ||
+				attr.toLowerCase() === "text")
+		);
+	}
+};
+
+function namePseudo(names){
+	if(typeof Set !== "undefined"){
+		// eslint-disable-next-line no-undef
+		var nameSet = new Set(names);
+
+		return function(elem, adapter){
+			return nameSet.has(adapter.getName(elem));
+		};
 	}
 
-	//while filters are precompiled, pseudos get called when they are needed
-	var pseudos = {
-		empty: function(elem){
-			return !adapter.getChildren(elem).some(function(elem){
-				return adapter.isTag(elem) || elem.type === "text";
-			});
-		},
-
-		"first-child": function(elem){
-			return getFirstElement(adapter.getSiblings(elem)) === elem;
-		},
-		"last-child": function(elem){
-			var siblings = adapter.getSiblings(elem);
-
-			for(var i = siblings.length - 1; i >= 0; i--){
-				if(siblings[i] === elem) return true;
-				if(adapter.isTag(siblings[i])) break;
-			}
-
-			return false;
-		},
-		"first-of-type": function(elem){
-			var siblings = adapter.getSiblings(elem);
-
-			for(var i = 0; i < siblings.length; i++){
-				if(adapter.isTag(siblings[i])){
-					if(siblings[i] === elem) return true;
-					if(adapter.getName(siblings[i]) === adapter.getName(elem)) break;
-				}
-			}
-
-			return false;
-		},
-		"last-of-type": function(elem){
-			var siblings = adapter.getSiblings(elem);
-
-			for(var i = siblings.length - 1; i >= 0; i--){
-				if(adapter.isTag(siblings[i])){
-					if(siblings[i] === elem) return true;
-					if(adapter.getName(siblings[i]) === adapter.getName(elem)) break;
-				}
-			}
-
-			return false;
-		},
-		"only-of-type": function(elem){
-			var siblings = adapter.getSiblings(elem);
-
-			for(var i = 0, j = siblings.length; i < j; i++){
-				if(adapter.isTag(siblings[i])){
-					if(siblings[i] === elem) continue;
-					if(adapter.getName(siblings[i]) === adapter.getName(elem)) return false;
-				}
-			}
-
-			return true;
-		},
-		"only-child": function(elem){
-			var siblings = adapter.getSiblings(elem);
-
-			for(var i = 0; i < siblings.length; i++){
-				if(adapter.isTag(siblings[i]) && siblings[i] !== elem) return false;
-			}
-
-			return true;
-		},
-
-		//:matches(a, area, link)[href]
-		link: function(elem){
-			return adapter.hasAttrib(elem, "href");
-		},
-		visited: falseFunc, //seems to be a valid implementation
-		//TODO: :any-link once the name is finalized (as an alias of :link)
-
-		//forms
-		//to consider: :target
-
-		//:matches([selected], select:not([multiple]):not(> option[selected]) > option:first-of-type)
-		selected: function(elem){
-			if(adapter.hasAttrib(elem, "selected")) return true;
-			else if(adapter.getName(elem) !== "option") return false;
-
-			//the first <option> in a <select> is also selected
-			var parent = adapter.getParent(elem);
-
-			if(
-				!parent ||
-				adapter.getName(parent) !== "select" ||
-				adapter.hasAttrib(parent, "multiple")
-			) return false;
-
-			var siblings = adapter.getChildren(parent),
-				sawElem  = false;
-
-			for(var i = 0; i < siblings.length; i++){
-				if(adapter.isTag(siblings[i])){
-					if(siblings[i] === elem){
-						sawElem = true;
-					} else if(!sawElem){
-						return false;
-					} else if(adapter.hasAttrib(siblings[i], "selected")){
-						return false;
-					}
-				}
-			}
-
-			return sawElem;
-		},
-		//https://html.spec.whatwg.org/multipage/scripting.html#disabled-elements
-		//:matches(
-		//  :matches(button, input, select, textarea, menuitem, optgroup, option)[disabled],
-		//  optgroup[disabled] > option),
-		// fieldset[disabled] * //TODO not child of first <legend>
-		//)
-		disabled: function(elem){
-			return adapter.hasAttrib(elem, "disabled");
-		},
-		enabled: function(elem){
-			return !adapter.hasAttrib(elem, "disabled");
-		},
-		//:matches(:matches(:radio, :checkbox)[checked], :selected) (TODO menuitem)
-		checked: function(elem){
-			return adapter.hasAttrib(elem, "checked") || pseudos.selected(elem);
-		},
-		//:matches(input, select, textarea)[required]
-		required: function(elem){
-			return adapter.hasAttrib(elem, "required");
-		},
-		//:matches(input, select, textarea):not([required])
-		optional: function(elem){
-			return !adapter.hasAttrib(elem, "required");
-		},
-
-		//jQuery extensions
-
-		//:not(:empty)
-		parent: function(elem){
-			return !pseudos.empty(elem);
-		},
-		//:matches(h1, h2, h3, h4, h5, h6)
-		header: function(elem){
-			var name = adapter.getName(elem);
-			return name === "h1" ||
-					name === "h2" ||
-					name === "h3" ||
-					name === "h4" ||
-					name === "h5" ||
-					name === "h6";
-		},
-
-		//:matches(button, input[type=button])
-		button: function(elem){
-			var name = adapter.getName(elem);
-			return name === "button" ||
-					name === "input" &&
-					adapter.getAttributeValue(elem, "type") === "button";
-		},
-		//:matches(input, textarea, select, button)
-		input: function(elem){
-			var name = adapter.getName(elem);
-			return name === "input" ||
-					name === "textarea" ||
-					name === "select" ||
-					name === "button";
-		},
-		//input:matches(:not([type!='']), [type='text' i])
-		text: function(elem){
-			var attr;
-			return adapter.getName(elem) === "input" && (
-				!(attr = adapter.getAttributeValue(elem, "type")) ||
-				attr.toLowerCase() === "text"
-			);
-		}
+	return function(elem, adapter){
+		return names.indexOf(adapter.getName(elem)) >= 0;
 	};
-
-	return pseudos;
 }
 
 function verifyArgs(func, name, subselect){
 	if(subselect === null){
-		if(func.length > 1 && name !== "scope"){
+		if(func.length > 2 && name !== "scope"){
 			throw new Error("pseudo-selector :" + name + " requires an argument");
 		}
 	} else {
-		if(func.length === 1){
-			throw new Error("pseudo-selector :" + name + " doesn't have any arguments");
+		if(func.length === 2){
+			throw new Error(
+				"pseudo-selector :" + name + " doesn't have any arguments"
+			);
 		}
 	}
 }
@@ -371,38 +390,39 @@ function verifyArgs(func, name, subselect){
 //FIXME this feels hacky
 var re_CSS3 = /^(?:(?:nth|last|first|only)-(?:child|of-type)|root|empty|(?:en|dis)abled|checked|not)$/;
 
-function factory(adapter){
-	var pseudos = pseudosFactory(adapter);
-	var filters = filtersFactory(adapter);
+module.exports = {
+	compile: function(next, data, options, context){
+		var name = data.name;
+		var subselect = data.data;
+		var adapter = options.adapter;
 
-	return {
-		compile: function(next, data, options, context){
-			var name = data.name,
-				subselect = data.data;
+		if(options && options.strict && !re_CSS3.test(name)){
+			throw new Error(":" + name + " isn't part of CSS3");
+		}
 
-			if(options && options.strict && !re_CSS3.test(name)){
-				throw new Error(":" + name + " isn't part of CSS3");
+		if(typeof filters[name] === "function"){
+			return filters[name](next, subselect, options, context);
+		} else if(typeof pseudos[name] === "function"){
+			var func = pseudos[name];
+			verifyArgs(func, name, subselect);
+
+			if(func === falseFunc){
+				return func;
 			}
 
-			if(typeof filters[name] === "function"){
-				verifyArgs(filters[name], name,  subselect);
-				return filters[name](next, subselect, options, context);
-			} else if(typeof pseudos[name] === "function"){
-				var func = pseudos[name];
-				verifyArgs(func, name, subselect);
-
-				if(next === trueFunc) return func;
-
-				return function pseudoArgs(elem){
-					return func(elem, subselect) && next(elem);
+			if(next === trueFunc){
+				return function pseudoRoot(elem){
+					return func(elem, adapter, subselect);
 				};
-			} else {
-				throw new Error("unmatched pseudo-class :" + name);
 			}
-		},
-		filters: filters,
-		pseudos: pseudos
-	};
-}
 
-module.exports = factory;
+			return function pseudoArgs(elem){
+				return func(elem, adapter, subselect) && next(elem);
+			};
+		} else {
+			throw new Error("unmatched pseudo-class :" + name);
+		}
+	},
+	filters: filters,
+	pseudos: pseudos
+};

--- a/test/api.js
+++ b/test/api.js
@@ -1,10 +1,10 @@
-var CSSselect = require(".."),
-	makeDom = require("htmlparser2").parseDOM,
-	bools = require("boolbase"),
-	assert = require("assert");
+var CSSselect = require("..");
+var makeDom = require("htmlparser2").parseDOM;
+var bools = require("boolbase");
+var assert = require("assert");
 
-var dom = makeDom("<div id=foo><p>foo</p></div>")[0],
-	xmlDom = makeDom("<DiV id=foo><P>foo</P></DiV>", {xmlMode: true})[0];
+var dom = makeDom("<div id=foo><p>foo</p></div>")[0];
+var xmlDom = makeDom("<DiV id=foo><P>foo</P></DiV>", { xmlMode: true })[0];
 
 describe("API", function(){
 	describe("removes duplicates", function(){
@@ -24,9 +24,11 @@ describe("API", function(){
 
 	describe("can be queried by function", function(){
 		it("in `is`", function(){
-			assert(CSSselect.is(dom, function(elem){
-				return elem.attribs.id === "foo";
-			}));
+			assert(
+				CSSselect.is(dom, function(elem){
+					return elem.attribs.id === "foo";
+				})
+			);
 		});
 		//probably more cases should be added here
 	});
@@ -77,7 +79,10 @@ describe("API", function(){
 			assert.equal(matches.length, 2);
 			matches = CSSselect.selectAll(":matches(div, :not(div))", [dom]);
 			assert.equal(matches.length, 2);
-			matches = CSSselect.selectAll(":matches(boo, baa, tag, div, foo, bar, baz)", [dom]);
+			matches = CSSselect.selectAll(
+				":matches(boo, baa, tag, div, foo, bar, baz)",
+				[dom]
+			);
 			assert.equal(matches.length, 1);
 			assert.equal(matches[0], dom);
 		});
@@ -119,15 +124,15 @@ describe("API", function(){
 	});
 
 	describe("options", function(){
-		var opts = {xmlMode: true};
+		var opts = { xmlMode: true };
 		it("should recognize xmlMode in :has and :not", function(){
-			assert(CSSselect.is(xmlDom, "DiV:has(P)",   opts));
+			assert(CSSselect.is(xmlDom, "DiV:has(P)", opts));
 			assert(CSSselect.is(xmlDom, "DiV:not(div)", opts));
 			assert(CSSselect.is(xmlDom.children[0], "DiV:has(P) :not(p)", opts));
 		});
 
 		it("should be strict", function(){
-			var opts = {strict: true};
+			var opts = { strict: true };
 			assert.throws(CSSselect.compile.bind(null, ":checkbox", opts), Error);
 			assert.throws(CSSselect.compile.bind(null, "[attr=val i]", opts), Error);
 			assert.throws(CSSselect.compile.bind(null, "[attr!=val]", opts), Error);
@@ -135,16 +140,16 @@ describe("API", function(){
 			assert.throws(CSSselect.compile.bind(null, "foo < bar", opts), Error);
 			assert.throws(CSSselect.compile.bind(null, ":not(:parent)", opts), Error);
 			assert.throws(CSSselect.compile.bind(null, ":not(a > b)", opts), Error);
-			assert.throws(CSSselect.compile.bind(null, ":not(a, b)",  opts), Error);
+			assert.throws(CSSselect.compile.bind(null, ":not(a, b)", opts), Error);
 		});
 
 		it("should recognize contexts", function(){
 			var div = CSSselect.selectAll("div", [dom]),
-			    p = CSSselect.selectAll("p", [dom]);
+				p = CSSselect.selectAll("p", [dom]);
 
-			assert.equal(CSSselect.selectOne("div", div, {context: div}), div[0]);
-			assert.equal(CSSselect.selectOne("div", div, {context: p}), null);
-			assert.deepEqual(CSSselect.selectAll("p", div, {context: div}), p);
+			assert.equal(CSSselect.selectOne("div", div, { context: div }), div[0]);
+			assert.equal(CSSselect.selectOne("div", div, { context: p }), null);
+			assert.deepEqual(CSSselect.selectAll("p", div, { context: div }), p);
 		});
 	});
 });

--- a/test/attributes.js
+++ b/test/attributes.js
@@ -3,15 +3,23 @@ var CSSselect = require("../"),
 	falseFunc = require("boolbase").falseFunc,
 	assert = require("assert");
 
-var dom = makeDom("<div><div data-foo=\"In the end, it doesn't really matter.\"></div><div data-foo=\"Indeed-that's a delicate matter.\">");
+var dom = makeDom(
+	"<div><div data-foo=\"In the end, it doesn't really matter.\"></div><div data-foo=\"Indeed-that's a delicate matter.\">"
+);
 
 describe("Attributes", function(){
 	describe("ignore case", function(){
 		it("should for =", function(){
-			var matches = CSSselect.selectAll("[data-foo=\"indeed-that's a delicate matter.\" i]", dom);
+			var matches = CSSselect.selectAll(
+				"[data-foo=\"indeed-that's a delicate matter.\" i]",
+				dom
+			);
 			assert.equal(matches.length, 1);
 			assert.deepEqual(matches, [dom[0].children[1]]);
-			matches = CSSselect.selectAll("[data-foo=\"inDeeD-THAT's a DELICATE matteR.\" i]", dom);
+			matches = CSSselect.selectAll(
+				"[data-foo=\"inDeeD-THAT's a DELICATE matteR.\" i]",
+				dom
+			);
 			assert.deepEqual(matches, [dom[0].children[1]]);
 		});
 
@@ -36,10 +44,16 @@ describe("Attributes", function(){
 		});
 
 		it("should for !=", function(){
-			var matches = CSSselect.selectAll("[data-foo!=\"indeed-that's a delicate matter.\" i]", dom);
+			var matches = CSSselect.selectAll(
+				"[data-foo!=\"indeed-that's a delicate matter.\" i]",
+				dom
+			);
 			assert.equal(matches.length, 1);
 			assert.deepEqual(matches, [dom[0].children[0]]);
-			matches = CSSselect.selectAll("[data-foo!=\"inDeeD-THAT's a DELICATE matteR.\" i]", dom);
+			matches = CSSselect.selectAll(
+				"[data-foo!=\"inDeeD-THAT's a DELICATE matteR.\" i]",
+				dom
+			);
 			assert.deepEqual(matches, [dom[0].children[0]]);
 		});
 

--- a/test/icontains.js
+++ b/test/icontains.js
@@ -2,15 +2,23 @@ var CSSselect = require("../"),
 	makeDom = require("htmlparser2").parseDOM,
 	assert = require("assert");
 
-var dom = makeDom("<div><p>In the end, it doesn't really Matter.</p><div>Indeed-that's a delicate matter.</div>");
+var dom = makeDom(
+	"<div><p>In the end, it doesn't really Matter.</p><div>Indeed-that's a delicate matter.</div>"
+);
 
 describe("icontains", function(){
 	describe("ignore case", function(){
 		it("should match full string", function(){
-			var matches = CSSselect.selectAll(":icontains(indeed-that's a delicate matter.)", dom);
+			var matches = CSSselect.selectAll(
+				":icontains(indeed-that's a delicate matter.)",
+				dom
+			);
 			assert.equal(matches.length, 2);
 			assert.deepEqual(matches, [dom[0], dom[0].children[1]]);
-			matches = CSSselect.selectAll(":icontains(inDeeD-THAT's a DELICATE matteR.)", dom);
+			matches = CSSselect.selectAll(
+				":icontains(inDeeD-THAT's a DELICATE matteR.)",
+				dom
+			);
 			assert.equal(matches.length, 2);
 			assert.deepEqual(matches, [dom[0], dom[0].children[1]]);
 		});
@@ -36,26 +44,38 @@ describe("icontains", function(){
 		it("should match multiple elements", function(){
 			var matches = CSSselect.selectAll(":icontains(matter)", dom);
 			assert.equal(matches.length, 3);
-			assert.deepEqual(matches, [dom[0], dom[0].children[0],
-				dom[0].children[1]]);
+			assert.deepEqual(matches, [
+				dom[0],
+				dom[0].children[0],
+				dom[0].children[1]
+			]);
 			matches = CSSselect.selectAll(":icontains(mATter)", dom);
 			assert.equal(matches.length, 3);
-			assert.deepEqual(matches, [dom[0], dom[0].children[0],
-				dom[0].children[1]]);
+			assert.deepEqual(matches, [
+				dom[0],
+				dom[0].children[0],
+				dom[0].children[1]
+			]);
 		});
 
 		it("should match empty string", function(){
 			var matches = CSSselect.selectAll(":icontains()", dom);
 			assert.equal(matches.length, 3);
-			assert.deepEqual(matches, [dom[0], dom[0].children[0],
-				dom[0].children[1]]);
+			assert.deepEqual(matches, [
+				dom[0],
+				dom[0].children[0],
+				dom[0].children[1]
+			]);
 		});
 
 		it("should match quoted string", function(){
 			var matches = CSSselect.selectAll(":icontains('')", dom);
 			assert.equal(matches.length, 3);
-			assert.deepEqual(matches, [dom[0], dom[0].children[0],
-				dom[0].children[1]]);
+			assert.deepEqual(matches, [
+				dom[0],
+				dom[0].children[0],
+				dom[0].children[1]
+			]);
 			matches = CSSselect.selectAll("p:icontains('matter')", dom);
 			assert.equal(matches.length, 1);
 			assert.deepEqual(matches, [dom[0].children[0]]);
@@ -67,12 +87,18 @@ describe("icontains", function(){
 		it("should match whitespace", function(){
 			var matches = CSSselect.selectAll(":icontains( matter)", dom);
 			assert.equal(matches.length, 3);
-			assert.deepEqual(matches, [dom[0], dom[0].children[0],
-				dom[0].children[1]]);
+			assert.deepEqual(matches, [
+				dom[0],
+				dom[0].children[0],
+				dom[0].children[1]
+			]);
 			matches = CSSselect.selectAll(":icontains( mATter)", dom);
 			assert.equal(matches.length, 3);
-			assert.deepEqual(matches, [dom[0], dom[0].children[0],
-				dom[0].children[1]]);
+			assert.deepEqual(matches, [
+				dom[0],
+				dom[0].children[0],
+				dom[0].children[1]
+			]);
 		});
 	});
 
@@ -81,6 +107,5 @@ describe("icontains", function(){
 			var matches = CSSselect.selectAll("p:icontains(indeed)", dom);
 			assert.equal(matches.length, 0);
 		});
-
 	});
 });

--- a/test/nwmatcher/index.js
+++ b/test/nwmatcher/index.js
@@ -17,10 +17,11 @@ function getById(element){
 			return DomUtils.getElementById(element, document);
 		}
 		return element;
+	} else {
+		return Array.prototype.map.call(arguments, function(elem){
+			return getById(elem);
+		});
 	}
-	else {return Array.prototype.map.call(arguments, function(elem){
-		return getById(elem);
-	});}
 }
 
 //NWMatcher methods
@@ -28,13 +29,14 @@ var select = function(query, doc){
 		if(arguments.length === 1 || typeof doc === "undefined") doc = document;
 		else if(typeof doc === "string") doc = select(doc);
 		return CSSselect(query, doc);
-	}, match = CSSselect.is;
+	},
+	match = CSSselect.is;
 
 var validators = {
 	assert: assert,
 	assertEqual: assert.equal,
-	assertEquivalent: function(v1, v2, message) {
-		return assert.deepEqual(decircularize(v1), decircularize(v2), message)
+	assertEquivalent: function(v1, v2, message){
+		return assert.deepEqual(decircularize(v1), decircularize(v2), message);
 	},
 	refute: function refute(a, msg){
 		assert(!a, msg);
@@ -62,7 +64,7 @@ var runner = {
 			});
 		}
 	}
-}
+};
 
 var RUN_BENCHMARKS = false;
 //The tests...
@@ -70,22 +72,35 @@ var RUN_BENCHMARKS = false;
 	runner.addGroup("Basic Selectors").addTests(null, {
 		"*": function(){
 			//Universal selector
-			var results = [], nodes = document.getElementsByTagName("*"), index = 0, length = nodes.length, node;
+			var results = [],
+				nodes = document.getElementsByTagName("*"),
+				index = 0,
+				length = nodes.length,
+				node;
 			//Collect all element nodes, excluding comments (IE)
 			for(; index < length; index++){
 				if((node = nodes[index]).tagName !== "!"){
 					results[results.length] = node;
 				}
 			}
-			this.assertEquivalent(select("*"), results, "Comment nodes should be ignored.");
+			this.assertEquivalent(
+				select("*"),
+				results,
+				"Comment nodes should be ignored."
+			);
 		},
-		"E": function(){
+		E: function(){
 			//Type selector
-			var results = [], index = 0, nodes = document.getElementsByTagName("li");
+			var results = [],
+				index = 0,
+				nodes = document.getElementsByTagName("li");
 			while((results[index] = nodes[index++]));
 			results.length--;
 			//  this.assertEquivalent(select("li"), results); //TODO
-			this.assertEqual(select("strong", getById("fixtures"))[0], getById("strong"));
+			this.assertEqual(
+				select("strong", getById("fixtures"))[0],
+				getById("strong")
+			);
 			this.assertEquivalent(select("nonexistent"), []);
 		},
 		"#id": function(){
@@ -129,48 +144,117 @@ var RUN_BENCHMARKS = false;
 
 	runner.addGroup("Attribute Selectors").addTests(null, {
 		"[foo]": function(){
-			this.assertEquivalent(select("[href]", document.body), select("a[href]", document.body));
-			this.assertEquivalent(select("[class~=internal]"), select("a[class~=\"internal\"]"));
+			this.assertEquivalent(
+				select("[href]", document.body),
+				select("a[href]", document.body)
+			);
+			this.assertEquivalent(
+				select("[class~=internal]"),
+				select("a[class~=\"internal\"]")
+			);
 			this.assertEquivalent(select("[id]"), select("*[id]"));
-			this.assertEquivalent(select("[type=radio]"), getById("checked_radio", "unchecked_radio"));
-			this.assertEquivalent(select("[type=checkbox]"), select("*[type=checkbox]"));
-			this.assertEquivalent(select("[title]"), getById("with_title", "commaParent"));
-			this.assertEquivalent(select("#troubleForm [type=radio]"), select("#troubleForm *[type=radio]"));
-			this.assertEquivalent(select("#troubleForm [type]"), select("#troubleForm *[type]"));
+			this.assertEquivalent(
+				select("[type=radio]"),
+				getById("checked_radio", "unchecked_radio")
+			);
+			this.assertEquivalent(
+				select("[type=checkbox]"),
+				select("*[type=checkbox]")
+			);
+			this.assertEquivalent(
+				select("[title]"),
+				getById("with_title", "commaParent")
+			);
+			this.assertEquivalent(
+				select("#troubleForm [type=radio]"),
+				select("#troubleForm *[type=radio]")
+			);
+			this.assertEquivalent(
+				select("#troubleForm [type]"),
+				select("#troubleForm *[type]")
+			);
 		},
 		"E[foo]": function(){
-			this.assertEquivalent(select("h1[class]"), select("#fixtures h1"), "h1[class]");
-			this.assertEquivalent(select("h1[CLASS]"), select("#fixtures h1"), "h1[CLASS]");
-			this.assertEqual(select("li#item_3[class]")[0], getById("item_3"), "li#item_3[class]");
-			this.assertEquivalent(select("#troubleForm2 input[name=\"brackets[5][]\"]"), getById("chk_1", "chk_2"));
+			this.assertEquivalent(
+				select("h1[class]"),
+				select("#fixtures h1"),
+				"h1[class]"
+			);
+			this.assertEquivalent(
+				select("h1[CLASS]"),
+				select("#fixtures h1"),
+				"h1[CLASS]"
+			);
+			this.assertEqual(
+				select("li#item_3[class]")[0],
+				getById("item_3"),
+				"li#item_3[class]"
+			);
+			this.assertEquivalent(
+				select("#troubleForm2 input[name=\"brackets[5][]\"]"),
+				getById("chk_1", "chk_2")
+			);
 			//Brackets in attribute value
-			this.assertEqual(select("#troubleForm2 input[name=\"brackets[5][]\"]:checked")[0], getById("chk_1"));
+			this.assertEqual(
+				select("#troubleForm2 input[name=\"brackets[5][]\"]:checked")[0],
+				getById("chk_1")
+			);
 			//Space in attribute value
-			this.assertEqual(select("cite[title=\"hello world!\"]")[0], getById("with_title"));
+			this.assertEqual(
+				select("cite[title=\"hello world!\"]")[0],
+				getById("with_title")
+			);
 			//Namespaced attributes
 			//  this.assertEquivalent(select('[xml:lang]'), [document.documentElement, getById("item_3")]);
 			//  this.assertEquivalent(select('*[xml:lang]'), [document.documentElement, getById("item_3")]);
 		},
 		"E[foo=\"bar\"]": function(){
-			this.assertEquivalent(select("a[href=\"#\"]"), getById("link_1", "link_2", "link_3"));
+			this.assertEquivalent(
+				select("a[href=\"#\"]"),
+				getById("link_1", "link_2", "link_3")
+			);
 			this.assertThrowsException(/Error/, function(){
 				select("a[href=#]");
 			});
-			this.assertEqual(select("#troubleForm2 input[name=\"brackets[5][]\"][value=\"2\"]")[0], getById("chk_2"));
+			this.assertEqual(
+				select("#troubleForm2 input[name=\"brackets[5][]\"][value=\"2\"]")[0],
+				getById("chk_2")
+			);
 		},
 		"E[foo~=\"bar\"]": function(){
-			this.assertEquivalent(select("a[class~=\"internal\"]"), getById("link_1", "link_2"), "a[class~=\"internal\"]");
-			this.assertEquivalent(select("a[class~=internal]"), getById("link_1", "link_2"), "a[class~=internal]");
-			this.assertEqual(select("a[class~=external][href=\"#\"]")[0], getById("link_3"), "a[class~=external][href=\"#\"]");
-		},/*
-		'E[foo|="en"]': function(){
+			this.assertEquivalent(
+				select("a[class~=\"internal\"]"),
+				getById("link_1", "link_2"),
+				"a[class~=\"internal\"]"
+			);
+			this.assertEquivalent(
+				select("a[class~=internal]"),
+				getById("link_1", "link_2"),
+				"a[class~=internal]"
+			);
+			this.assertEqual(
+				select("a[class~=external][href=\"#\"]")[0],
+				getById("link_3"),
+				"a[class~=external][href=\"#\"]"
+			);
+		}, /*		'E[foo|="en"]': function(){
 			this.assertEqual(select('*[xml:lang|="es"]')[0], getById('item_3'));
 			this.assertEqual(select('*[xml:lang|="ES"]')[0], getById('item_3'));
 		},*/
 		"E[foo^=\"bar\"]": function(){
-			this.assertEquivalent(select("div[class^=bro]"), getById("father", "uncle"), "matching beginning of string");
-			this.assertEquivalent(select("#level1 *[id^=\"level2_\"]"), getById("level2_1", "level2_2", "level2_3"));
-			this.assertEquivalent(select("#level1 *[id^=level2_]"), getById("level2_1", "level2_2", "level2_3"));
+			this.assertEquivalent(
+				select("div[class^=bro]"),
+				getById("father", "uncle"),
+				"matching beginning of string"
+			);
+			this.assertEquivalent(
+				select("#level1 *[id^=\"level2_\"]"),
+				getById("level2_1", "level2_2", "level2_3")
+			);
+			this.assertEquivalent(
+				select("#level1 *[id^=level2_]"),
+				getById("level2_1", "level2_2", "level2_3")
+			);
 			if(RUN_BENCHMARKS){
 				this.wait(function(){
 					this.benchmark(function(){
@@ -180,9 +264,19 @@ var RUN_BENCHMARKS = false;
 			}
 		},
 		"E[foo$=\"bar\"]": function(){
-			this.assertEquivalent(select("div[class$=men]"), getById("father", "uncle"), "matching end of string");
-			this.assertEquivalent(select("#level1 *[id$=\"_1\"]"), getById("level2_1", "level3_1"));
-			this.assertEquivalent(select("#level1 *[id$=_1]"), getById("level2_1", "level3_1"));
+			this.assertEquivalent(
+				select("div[class$=men]"),
+				getById("father", "uncle"),
+				"matching end of string"
+			);
+			this.assertEquivalent(
+				select("#level1 *[id$=\"_1\"]"),
+				getById("level2_1", "level3_1")
+			);
+			this.assertEquivalent(
+				select("#level1 *[id$=_1]"),
+				getById("level2_1", "level3_1")
+			);
 			if(RUN_BENCHMARKS){
 				this.wait(function(){
 					this.benchmark(function(){
@@ -192,8 +286,15 @@ var RUN_BENCHMARKS = false;
 			}
 		},
 		"E[foo*=\"bar\"]": function(){
-			this.assertEquivalent(select("div[class*=\"ers m\"]"), getById("father", "uncle"), "matching substring");
-			this.assertEquivalent(select("#level1 *[id*=\"2\"]"), getById("level2_1", "level3_2", "level2_2", "level2_3"));
+			this.assertEquivalent(
+				select("div[class*=\"ers m\"]"),
+				getById("father", "uncle"),
+				"matching substring"
+			);
+			this.assertEquivalent(
+				select("#level1 *[id*=\"2\"]"),
+				getById("level2_1", "level3_2", "level2_2", "level2_3")
+			);
 			this.assertThrowsException(/Error/, function(){
 				select("#level1 *[id*=2]");
 			});
@@ -206,7 +307,7 @@ var RUN_BENCHMARKS = false;
 			}
 		},
 
-	// *** these should throw SYNTAX_ERR ***
+		// *** these should throw SYNTAX_ERR ***
 
 		"E[id=-1]": function(){
 			this.assertThrowsException(/Error/, function(){
@@ -244,15 +345,20 @@ var RUN_BENCHMARKS = false;
 				}, 500);
 			}
 		}
-
 	});
 
 	runner.addGroup("Structural pseudo-classes").addTests(null, {
 		"E:first-child": function(){
 			this.assertEqual(select("#level1>*:first-child")[0], getById("level2_1"));
-			this.assertEquivalent(select("#level1 *:first-child"), getById("level2_1", "level3_1", "level_only_child"));
+			this.assertEquivalent(
+				select("#level1 *:first-child"),
+				getById("level2_1", "level3_1", "level_only_child")
+			);
 			this.assertEquivalent(select("#level1>div:first-child"), []);
-			this.assertEquivalent(select("#level1 span:first-child"), getById("level2_1", "level3_1"));
+			this.assertEquivalent(
+				select("#level1 span:first-child"),
+				getById("level2_1", "level3_1")
+			);
 			this.assertEquivalent(select("#level1:first-child"), []);
 			if(RUN_BENCHMARKS){
 				this.wait(function(){
@@ -264,9 +370,18 @@ var RUN_BENCHMARKS = false;
 		},
 		"E:last-child": function(){
 			this.assertEqual(select("#level1>*:last-child")[0], getById("level2_3"));
-			this.assertEquivalent(select("#level1 *:last-child"), getById("level3_2", "level_only_child", "level2_3"));
-			this.assertEqual(select("#level1>div:last-child")[0], getById("level2_3"));
-			this.assertEqual(select("#level1 div:last-child")[0], getById("level2_3"));
+			this.assertEquivalent(
+				select("#level1 *:last-child"),
+				getById("level3_2", "level_only_child", "level2_3")
+			);
+			this.assertEqual(
+				select("#level1>div:last-child")[0],
+				getById("level2_3")
+			);
+			this.assertEqual(
+				select("#level1 div:last-child")[0],
+				getById("level2_3")
+			);
 			this.assertEquivalent(select("#level1>span:last-child"), []);
 			if(RUN_BENCHMARKS){
 				this.wait(function(){
@@ -278,30 +393,69 @@ var RUN_BENCHMARKS = false;
 		},
 		"E:nth-child(n)": function(){
 			this.assertEqual(select("#p *:nth-child(3)")[0], getById("link_2"));
-			this.assertEqual(select("#p a:nth-child(3)")[0], getById("link_2"), "nth-child");
-			this.assertEquivalent(select("#list > li:nth-child(n+2)"), getById("item_2", "item_3"));
-			this.assertEquivalent(select("#list > li:nth-child(-n+2)"), getById("item_1", "item_2"));
+			this.assertEqual(
+				select("#p a:nth-child(3)")[0],
+				getById("link_2"),
+				"nth-child"
+			);
+			this.assertEquivalent(
+				select("#list > li:nth-child(n+2)"),
+				getById("item_2", "item_3")
+			);
+			this.assertEquivalent(
+				select("#list > li:nth-child(-n+2)"),
+				getById("item_1", "item_2")
+			);
 		},
 		"E:nth-of-type(n)": function(){
-			this.assertEqual(select("#p a:nth-of-type(2)")[0], getById("link_2"), "nth-of-type");
-			this.assertEqual(select("#p a:nth-of-type(1)")[0], getById("link_1"), "nth-of-type");
+			this.assertEqual(
+				select("#p a:nth-of-type(2)")[0],
+				getById("link_2"),
+				"nth-of-type"
+			);
+			this.assertEqual(
+				select("#p a:nth-of-type(1)")[0],
+				getById("link_1"),
+				"nth-of-type"
+			);
 		},
 		"E:nth-last-of-type(n)": function(){
-			this.assertEqual(select("#p a:nth-last-of-type(1)")[0], getById("link_2"), "nth-last-of-type");
+			this.assertEqual(
+				select("#p a:nth-last-of-type(1)")[0],
+				getById("link_2"),
+				"nth-last-of-type"
+			);
 		},
 		"E:first-of-type": function(){
-			this.assertEqual(select("#p a:first-of-type")[0], getById("link_1"), "first-of-type");
+			this.assertEqual(
+				select("#p a:first-of-type")[0],
+				getById("link_1"),
+				"first-of-type"
+			);
 		},
 		"E:last-of-type": function(){
-			this.assertEqual(select("#p a:last-of-type")[0], getById("link_2"), "last-of-type");
+			this.assertEqual(
+				select("#p a:last-of-type")[0],
+				getById("link_2"),
+				"last-of-type"
+			);
 		},
 		"E:only-child": function(){
-			this.assertEqual(select("#level1 *:only-child")[0], getById("level_only_child"));
+			this.assertEqual(
+				select("#level1 *:only-child")[0],
+				getById("level_only_child")
+			);
 			//Shouldn't return anything
 			this.assertEquivalent(select("#level1>*:only-child"), []);
 			this.assertEquivalent(select("#level1:only-child"), []);
-			this.assertEquivalent(select("#level2_2 :only-child:not(:last-child)"), []);
-			this.assertEquivalent(select("#level2_2 :only-child:not(:first-child)"), []);
+			this.assertEquivalent(
+				select("#level2_2 :only-child:not(:last-child)"),
+				[]
+			);
+			this.assertEquivalent(
+				select("#level2_2 :only-child:not(:first-child)"),
+				[]
+			);
 			if(RUN_BENCHMARKS){
 				this.wait(function(){
 					this.benchmark(function(){
@@ -313,10 +467,22 @@ var RUN_BENCHMARKS = false;
 		"E:empty": function(){
 			getById("level3_1").children = [];
 			if(document.createEvent){
-				this.assertEquivalent(select("#level1 *:empty"), getById("level3_1", "level3_2", "level2_3"), "#level1 *:empty");
-				this.assertEquivalent(select("#level_only_child:empty"), [], "newlines count as content!");
+				this.assertEquivalent(
+					select("#level1 *:empty"),
+					getById("level3_1", "level3_2", "level2_3"),
+					"#level1 *:empty"
+				);
+				this.assertEquivalent(
+					select("#level_only_child:empty"),
+					[],
+					"newlines count as content!"
+				);
 			} else {
-				this.assertEqual(select("#level3_1:empty")[0], getById("level3_1"), "IE forced empty content!");
+				this.assertEqual(
+					select("#level3_1:empty")[0],
+					getById("level3_1"),
+					"IE forced empty content!"
+				);
 				//this.skip("IE forced empty content!");
 			}
 			//Shouldn't return anything
@@ -329,40 +495,103 @@ var RUN_BENCHMARKS = false;
 			//Negation pseudo-class
 			this.assertEquivalent(select("a:not([href=\"#\"])"), []);
 			this.assertEquivalent(select("div.brothers:not(.brothers)"), []);
-			this.assertEquivalent(select("a[class~=external]:not([href=\"#\"])"), [], "a[class~=external][href!=\"#\"]");
-			this.assertEqual(select("#p a:not(:first-of-type)")[0], getById("link_2"), "first-of-type");
-			this.assertEqual(select("#p a:not(:last-of-type)")[0], getById("link_1"), "last-of-type");
-			this.assertEqual(select("#p a:not(:nth-of-type(1))")[0], getById("link_2"), "nth-of-type");
-			this.assertEqual(select("#p a:not(:nth-last-of-type(1))")[0], getById("link_1"), "nth-last-of-type");
-			this.assertEqual(select("#p a:not([rel~=nofollow])")[0], getById("link_2"), "attribute 1");
-			this.assertEqual(select("#p a:not([rel^=external])")[0], getById("link_2"), "attribute 2");
-			this.assertEqual(select("#p a:not([rel$=nofollow])")[0], getById("link_2"), "attribute 3");
-			this.assertEqual(select("#p a:not([rel$=\"nofollow\"]) > em")[0], getById("em"), "attribute 4");
-			this.assertEqual(select("#list li:not(#item_1):not(#item_3)")[0], getById("item_2"), "adjacent :not clauses");
-			this.assertEqual(select("#grandfather > div:not(#uncle) #son")[0], getById("son"));
-			this.assertEqual(select("#p a:not([rel$=\"nofollow\"]) em")[0], getById("em"), "attribute 4 + all descendants");
-			this.assertEqual(select("#p a:not([rel$=\"nofollow\"])>em")[0], getById("em"), "attribute 4 (without whitespace)");
+			this.assertEquivalent(
+				select("a[class~=external]:not([href=\"#\"])"),
+				[],
+				"a[class~=external][href!=\"#\"]"
+			);
+			this.assertEqual(
+				select("#p a:not(:first-of-type)")[0],
+				getById("link_2"),
+				"first-of-type"
+			);
+			this.assertEqual(
+				select("#p a:not(:last-of-type)")[0],
+				getById("link_1"),
+				"last-of-type"
+			);
+			this.assertEqual(
+				select("#p a:not(:nth-of-type(1))")[0],
+				getById("link_2"),
+				"nth-of-type"
+			);
+			this.assertEqual(
+				select("#p a:not(:nth-last-of-type(1))")[0],
+				getById("link_1"),
+				"nth-last-of-type"
+			);
+			this.assertEqual(
+				select("#p a:not([rel~=nofollow])")[0],
+				getById("link_2"),
+				"attribute 1"
+			);
+			this.assertEqual(
+				select("#p a:not([rel^=external])")[0],
+				getById("link_2"),
+				"attribute 2"
+			);
+			this.assertEqual(
+				select("#p a:not([rel$=nofollow])")[0],
+				getById("link_2"),
+				"attribute 3"
+			);
+			this.assertEqual(
+				select("#p a:not([rel$=\"nofollow\"]) > em")[0],
+				getById("em"),
+				"attribute 4"
+			);
+			this.assertEqual(
+				select("#list li:not(#item_1):not(#item_3)")[0],
+				getById("item_2"),
+				"adjacent :not clauses"
+			);
+			this.assertEqual(
+				select("#grandfather > div:not(#uncle) #son")[0],
+				getById("son")
+			);
+			this.assertEqual(
+				select("#p a:not([rel$=\"nofollow\"]) em")[0],
+				getById("em"),
+				"attribute 4 + all descendants"
+			);
+			this.assertEqual(
+				select("#p a:not([rel$=\"nofollow\"])>em")[0],
+				getById("em"),
+				"attribute 4 (without whitespace)"
+			);
 		}
 	});
 
 	runner.addGroup("UI element states pseudo-classes").addTests(null, {
 		"E:disabled": function(){
-			this.assertEqual(select("#troubleForm > p > *:disabled")[0], getById("disabled_text_field"));
+			this.assertEqual(
+				select("#troubleForm > p > *:disabled")[0],
+				getById("disabled_text_field")
+			);
 		},
 		"E:checked": function(){
-			this.assertEquivalent(select("#troubleForm *:checked"), getById("checked_box", "checked_radio"));
+			this.assertEquivalent(
+				select("#troubleForm *:checked"),
+				getById("checked_box", "checked_radio")
+			);
 		}
 	});
 
 	runner.addGroup("Combinators").addTests(null, {
 		"E F": function(){
 			//Descendant
-			this.assertEquivalent(select("#fixtures a *"), getById("em2", "em", "span"));
+			this.assertEquivalent(
+				select("#fixtures a *"),
+				getById("em2", "em", "span")
+			);
 			this.assertEqual(select("div#fixtures p")[0], getById("p"));
 		},
 		"E + F": function(){
 			//Adjacent sibling
-			this.assertEqual(select("div.brothers + div.brothers")[0], getById("uncle"));
+			this.assertEqual(
+				select("div.brothers + div.brothers")[0],
+				getById("uncle")
+			);
 			this.assertEqual(select("div.brothers + div")[0], getById("uncle"));
 			this.assertEqual(select("#level2_1+span")[0], getById("level2_2"));
 			this.assertEqual(select("#level2_1 + span")[0], getById("level2_2"));
@@ -373,14 +602,35 @@ var RUN_BENCHMARKS = false;
 			this.assertEquivalent(select("#level3_2 + *"), []);
 			this.assertEquivalent(select("#level3_1 + em"), []);
 
-			this.assertEqual(select("+ div.brothers", select("div.brothers"))[0], getById("uncle"));
-			this.assertEqual(select("+ div", select("div.brothers"))[0], getById("uncle"));
-			this.assertEqual(select("+span", select("#level2_1"))[0], getById("level2_2"));
-			this.assertEqual(select("+ span", select("#level2_1"))[0], getById("level2_2"));
-			this.assertEqual(select("+ *", select("#level2_1"))[0], getById("level2_2"));
+			this.assertEqual(
+				select("+ div.brothers", select("div.brothers"))[0],
+				getById("uncle")
+			);
+			this.assertEqual(
+				select("+ div", select("div.brothers"))[0],
+				getById("uncle")
+			);
+			this.assertEqual(
+				select("+span", select("#level2_1"))[0],
+				getById("level2_2")
+			);
+			this.assertEqual(
+				select("+ span", select("#level2_1"))[0],
+				getById("level2_2")
+			);
+			this.assertEqual(
+				select("+ *", select("#level2_1"))[0],
+				getById("level2_2")
+			);
 			this.assertEquivalent(select("+ span", select("#level2_2")), []);
-			this.assertEqual(select("+ span", select("#level3_1"))[0], getById("level3_2"));
-			this.assertEqual(select("+ *", select("#level3_1"))[0], getById("level3_2"));
+			this.assertEqual(
+				select("+ span", select("#level3_1"))[0],
+				getById("level3_2")
+			);
+			this.assertEqual(
+				select("+ *", select("#level3_1"))[0],
+				getById("level3_2")
+			);
 			this.assertEquivalent(select("+ *", select("#level3_2")), []);
 			this.assertEquivalent(select("+ em", select("#level3_1")), []);
 
@@ -395,17 +645,44 @@ var RUN_BENCHMARKS = false;
 		"E > F": function(){
 			//Child
 			this.assertEquivalent(select("p.first > a"), getById("link_1", "link_2"));
-			this.assertEquivalent(select("div#grandfather > div"), getById("father", "uncle"));
-			this.assertEquivalent(select("#level1>span"), getById("level2_1", "level2_2"));
-			this.assertEquivalent(select("#level1 > span"), getById("level2_1", "level2_2"));
-			this.assertEquivalent(select("#level2_1 > *"), getById("level3_1", "level3_2"));
+			this.assertEquivalent(
+				select("div#grandfather > div"),
+				getById("father", "uncle")
+			);
+			this.assertEquivalent(
+				select("#level1>span"),
+				getById("level2_1", "level2_2")
+			);
+			this.assertEquivalent(
+				select("#level1 > span"),
+				getById("level2_1", "level2_2")
+			);
+			this.assertEquivalent(
+				select("#level2_1 > *"),
+				getById("level3_1", "level3_2")
+			);
 			this.assertEquivalent(select("div > #nonexistent"), []);
 
-			this.assertEquivalent(select("> a", select("p.first")), getById("link_1", "link_2"));
-			this.assertEquivalent(select("> div", select("div#grandfather")), getById("father", "uncle"));
-			this.assertEquivalent(select(">span", select("#level1")), getById("level2_1", "level2_2"));
-			this.assertEquivalent(select("> span", select("#level1")), getById("level2_1", "level2_2"));
-			this.assertEquivalent(select("> *", select("#level2_1")), getById("level3_1", "level3_2"));
+			this.assertEquivalent(
+				select("> a", select("p.first")),
+				getById("link_1", "link_2")
+			);
+			this.assertEquivalent(
+				select("> div", select("div#grandfather")),
+				getById("father", "uncle")
+			);
+			this.assertEquivalent(
+				select(">span", select("#level1")),
+				getById("level2_1", "level2_2")
+			);
+			this.assertEquivalent(
+				select("> span", select("#level1")),
+				getById("level2_1", "level2_2")
+			);
+			this.assertEquivalent(
+				select("> *", select("#level2_1")),
+				getById("level3_1", "level3_2")
+			);
 			this.assertEquivalent(select("> #nonexistent", select("div")), []);
 
 			if(RUN_BENCHMARKS){
@@ -425,7 +702,10 @@ var RUN_BENCHMARKS = false;
 			this.assertEquivalent(select("div ~ #level3_2"), []);
 			this.assertEquivalent(select("div ~ #level2_3"), []);
 			this.assertEqual(select("#level2_1 ~ span")[0], getById("level2_2"));
-			this.assertEquivalent(select("#level2_1 ~ *"), getById("level2_2", "level2_3"));
+			this.assertEquivalent(
+				select("#level2_1 ~ *"),
+				getById("level2_2", "level2_3")
+			);
 			this.assertEqual(select("#level3_1 ~ #level3_2")[0], getById("level3_2"));
 			this.assertEqual(select("span ~ #level3_2")[0], getById("level3_2"));
 
@@ -435,10 +715,22 @@ var RUN_BENCHMARKS = false;
 			this.assertEquivalent(select("~ em", select("#level3_1")), []);
 			this.assertEquivalent(select("~ #level3_2", select("div")), []);
 			this.assertEquivalent(select("~ #level2_3", select("div")), []);
-			this.assertEqual(select("~ span", select("#level2_1"))[0], getById("level2_2"));
-			this.assertEquivalent(select("~ *", select("#level2_1")), getById("level2_2", "level2_3"));
-			this.assertEqual(select("~ #level3_2", select("#level3_1"))[0], getById("level3_2"));
-			this.assertEqual(select("~ #level3_2", select("span"))[0], getById("level3_2"));
+			this.assertEqual(
+				select("~ span", select("#level2_1"))[0],
+				getById("level2_2")
+			);
+			this.assertEquivalent(
+				select("~ *", select("#level2_1")),
+				getById("level2_2", "level2_3")
+			);
+			this.assertEqual(
+				select("~ #level3_2", select("#level3_1"))[0],
+				getById("level3_2")
+			);
+			this.assertEqual(
+				select("~ #level3_2", select("span"))[0],
+				getById("level3_2")
+			);
 
 			if(RUN_BENCHMARKS){
 				this.wait(function(){
@@ -457,11 +749,17 @@ var RUN_BENCHMARKS = false;
 			this.assert(match(element, "span"));
 			this.assert(match(element, "span#dupL1"));
 			this.assert(match(element, "div > span"), "child combinator");
-			this.assert(match(element, "#dupContainer span"), "descendant combinator");
+			this.assert(
+				match(element, "#dupContainer span"),
+				"descendant combinator"
+			);
 			this.assert(match(element, "#dupL1"), "ID only");
 			this.assert(match(element, "span.span_foo"), "class name 1");
 			this.assert(match(element, "span.span_bar"), "class name 2");
-			this.assert(match(element, "span:first-child"), "first-child pseudoclass");
+			this.assert(
+				match(element, "span:first-child"),
+				"first-child pseudoclass"
+			);
 			//Refutations
 			this.refute(match(element, "span.span_wtf"), "bogus class name");
 			this.refute(match(element, "#dupL2"), "different ID");
@@ -476,27 +774,60 @@ var RUN_BENCHMARKS = false;
 			this.assert(match(getById("link_1"), "a[rel^='external']"));
 		},
 		"Equivalent Selectors": function(){
-			this.assertEquivalent(select("div.brothers"), select("div[class~=brothers]"));
-			this.assertEquivalent(select("div.brothers"), select("div[class~=brothers].brothers"));
-			this.assertEquivalent(select("div:not(.brothers)"), select("div:not([class~=brothers])"));
+			this.assertEquivalent(
+				select("div.brothers"),
+				select("div[class~=brothers]")
+			);
+			this.assertEquivalent(
+				select("div.brothers"),
+				select("div[class~=brothers].brothers")
+			);
+			this.assertEquivalent(
+				select("div:not(.brothers)"),
+				select("div:not([class~=brothers])")
+			);
 			this.assertEquivalent(select("li ~ li"), select("li:not(:first-child)"));
 			this.assertEquivalent(select("ul > li"), select("ul > li:nth-child(n)"));
-			this.assertEquivalent(select("ul > li:nth-child(even)"), select("ul > li:nth-child(2n)"));
-			this.assertEquivalent(select("ul > li:nth-child(odd)"), select("ul > li:nth-child(2n+1)"));
-			this.assertEquivalent(select("ul > li:first-child"), select("ul > li:nth-child(1)"));
-			this.assertEquivalent(select("ul > li:last-child"), select("ul > li:nth-last-child(1)"));
+			this.assertEquivalent(
+				select("ul > li:nth-child(even)"),
+				select("ul > li:nth-child(2n)")
+			);
+			this.assertEquivalent(
+				select("ul > li:nth-child(odd)"),
+				select("ul > li:nth-child(2n+1)")
+			);
+			this.assertEquivalent(
+				select("ul > li:first-child"),
+				select("ul > li:nth-child(1)")
+			);
+			this.assertEquivalent(
+				select("ul > li:last-child"),
+				select("ul > li:nth-last-child(1)")
+			);
 			/* Opera 10 does not accept values > 128 as a parameter to :nth-child
 			See <http://operawiki.info/ArtificialLimits> */
-			this.assertEquivalent(select("ul > li:nth-child(n-128)"), select("ul > li"));
+			this.assertEquivalent(
+				select("ul > li:nth-child(n-128)"),
+				select("ul > li")
+			);
 			this.assertEquivalent(select("ul>li"), select("ul > li"));
-			this.assertEquivalent(select("#p a:not([rel$=\"nofollow\"])>em"), select("#p a:not([rel$=\"nofollow\"]) > em"));
+			this.assertEquivalent(
+				select("#p a:not([rel$=\"nofollow\"])>em"),
+				select("#p a:not([rel$=\"nofollow\"]) > em")
+			);
 		},
 		"Multiple Selectors": function(){
 			//The next two assertions should return document-ordered lists of matching elements --Diego Perini
 			//  this.assertEquivalent(select('#list, .first,*[xml:lang="es-us"] , #troubleForm'), getById('p', 'link_1', 'list', 'item_1', 'item_3', 'troubleForm'));
 			//  this.assertEquivalent(select('#list, .first, *[xml:lang="es-us"], #troubleForm'), getById('p', 'link_1', 'list', 'item_1', 'item_3', 'troubleForm'));
-			this.assertEquivalent(select("form[title*=\"commas,\"], input[value=\"#commaOne,#commaTwo\"]"), getById("commaParent", "commaChild"));
-			this.assertEquivalent(select("form[title*=\"commas,\"], input[value=\"#commaOne,#commaTwo\"]"), getById("commaParent", "commaChild"));
+			this.assertEquivalent(
+				select("form[title*=\"commas,\"], input[value=\"#commaOne,#commaTwo\"]"),
+				getById("commaParent", "commaChild")
+			);
+			this.assertEquivalent(
+				select("form[title*=\"commas,\"], input[value=\"#commaOne,#commaTwo\"]"),
+				getById("commaParent", "commaChild")
+			);
 		}
 	});
 }(runner));

--- a/test/qwery/index.js
+++ b/test/qwery/index.js
@@ -7,7 +7,7 @@ var expect = require("expect.js"),
 	document = helper.getDocument(path.join(__dirname, "index.html")),
 	CSSselect = helper.CSSselect;
 
-var location = {hash: ""};
+var location = { hash: "" };
 CSSselect.pseudos.target = function(elem){
 	return elem.attribs && elem.attribs.id === location.hash.substr(1);
 };
@@ -18,43 +18,48 @@ CSSselect.pseudos.target = function(elem){
 	The following is taken from https://github.com/ded/qwery/blob/master/tests/tests.js
 */
 
-CSSselect.pseudos.humanoid = function(e){ return CSSselect.is(e, "li:contains(human)") || CSSselect.is(e, "ol:contains(human)"); };
+CSSselect.pseudos.humanoid = function(e){
+	return (
+		CSSselect.is(e, "li:contains(human)") ||
+		CSSselect.is(e, "ol:contains(human)")
+	);
+};
 
 var frag = helper.getDOM(
 	"<root><div class=\"d i v\">" +
 		"<p id=\"oooo\"><em></em><em id=\"emem\"></em></p>" +
-	"</div>" +
-	"<p id=\"sep\">" +
+		"</div>" +
+		"<p id=\"sep\">" +
 		"<div class=\"a\"><span></span></div>" +
-	"</p></root>"
+		"</p></root>"
 );
 
 var doc = helper.getDOM(
 	"<root><div id=\"hsoob\">" +
 		"<div class=\"a b\">" +
-			"<div class=\"d e sib\" test=\"fg\" id=\"booshTest\"><p><span id=\"spanny\"></span></p></div>" +
-			"<em nopass=\"copyrighters\" rel=\"copyright booshrs\" test=\"f g\" class=\"sib\"></em>" +
-			"<span class=\"h i a sib\"></span>" +
+		"<div class=\"d e sib\" test=\"fg\" id=\"booshTest\"><p><span id=\"spanny\"></span></p></div>" +
+		"<em nopass=\"copyrighters\" rel=\"copyright booshrs\" test=\"f g\" class=\"sib\"></em>" +
+		"<span class=\"h i a sib\"></span>" +
 		"</div>" +
 		"<p class=\"odd\"></p>" +
-	"</div>" +
-	"<div id=\"lonelyHsoob\"></div></root>"
+		"</div>" +
+		"<div id=\"lonelyHsoob\"></div></root>"
 );
 
 var el = DomUtils.getElementById("attr-child-boosh", document);
 
-var pseudos = DomUtils.getElementById("pseudos", document).children.filter(DomUtils.isTag);
+var pseudos = DomUtils.getElementById("pseudos", document).children.filter(
+	DomUtils.isTag
+);
 
 module.exports = {
-
-	"Contexts": {
-
-		"should be able to pass optional context": function (){
+	Contexts: {
+		"should be able to pass optional context": function(){
 			expect(CSSselect(".a", document)).to.have.length(3); //no context found 3 elements (.a)
 			expect(CSSselect(".a", CSSselect("#boosh", document))).to.have.length(2); //context found 2 elements (#boosh .a)
 		},
 
-/*
+		/*
 	'should be able to pass string as context': function() {
 		expect(CSSselect('.a', '#boosh')).to.have.length(2); //context found 2 elements(.a, #boosh)
 		expect(CSSselect('.a', '.a')).to.be.empty(); //context found 0 elements(.a, .a)
@@ -63,7 +68,7 @@ module.exports = {
 		expect(CSSselect('.b', '#boosh .b')).to.be.empty(); //context found 0 elements(.b, #boosh .b)
 	},
 */
-/*
+		/*
 	'should be able to pass qwery result as context': function() {
 		expect(CSSselect('.a', CSSselect('#boosh', document))).to.have.length(2); //context found 2 elements(.a, #boosh)
 		expect(CSSselect('.a', CSSselect('.a', document))).to.be.empty(); //context found 0 elements(.a, .a)
@@ -72,23 +77,35 @@ module.exports = {
 		expect(CSSselect('.b', CSSselect('#boosh .b', document))).to.be.empty(); //context found 0 elements(.b, #boosh .b)
 	},
 */
-		"should not return duplicates from combinators": function (){
+		"should not return duplicates from combinators": function(){
 			expect(CSSselect("#boosh,#boosh", document)).to.have.length(1); //two booshes dont make a thing go right
 			expect(CSSselect("#boosh,.apples,#boosh", document)).to.have.length(1); //two booshes and an apple dont make a thing go right
 		},
 
 		"byId sub-queries within context": function(){
-			expect(CSSselect("#booshTest", CSSselect("#boosh", document))).to.have.length(1); //found "#id #id"
-			expect(CSSselect(".a.b #booshTest", CSSselect("#boosh", document))).to.have.length(1); //found ".class.class #id"
-			expect(CSSselect(".a>#booshTest", CSSselect("#boosh", document))).to.have.length(1); //found ".class>#id"
-			expect(CSSselect(">.a>#booshTest", CSSselect("#boosh", document))).to.have.length(1); //found ">.class>#id"
-			expect(CSSselect("#boosh", CSSselect("#booshTest", document)).length).to.not.be.ok(); //shouldn't find #boosh (ancestor) within #booshTest (descendent)
-			expect(CSSselect("#boosh", CSSselect("#lonelyBoosh", document)).length).to.not.be.ok(); //shouldn't find #boosh within #lonelyBoosh (unrelated)
+			expect(
+				CSSselect("#booshTest", CSSselect("#boosh", document))
+			).to.have.length(1); //found "#id #id"
+			expect(
+				CSSselect(".a.b #booshTest", CSSselect("#boosh", document))
+			).to.have.length(1); //found ".class.class #id"
+			expect(
+				CSSselect(".a>#booshTest", CSSselect("#boosh", document))
+			).to.have.length(1); //found ".class>#id"
+			expect(
+				CSSselect(">.a>#booshTest", CSSselect("#boosh", document))
+			).to.have.length(1); //found ">.class>#id"
+			expect(
+				CSSselect("#boosh", CSSselect("#booshTest", document)).length
+			).to.not.be.ok(); //shouldn't find #boosh (ancestor) within #booshTest (descendent)
+			expect(
+				CSSselect("#boosh", CSSselect("#lonelyBoosh", document)).length
+			).to.not.be.ok(); //shouldn't find #boosh within #lonelyBoosh (unrelated)
 		}
 	},
 
 	"CSS 1": {
-		"get element by id": function (){
+		"get element by id": function(){
 			var result = CSSselect("#boosh", document);
 			expect(result[0]).to.be.ok(); //found element with id=boosh
 			expect(CSSselect("h1", document)[0]).to.be.ok(); //found 1 h1
@@ -101,7 +118,7 @@ module.exports = {
 			expect(CSSselect(".a>#booshTest", document)).to.have.length(1); //found ".class>#id"
 		},
 
-		"get elements by class": function (){
+		"get elements by class": function(){
 			expect(CSSselect("#boosh .a", document)).to.have.length(2); //found two elements
 			expect(CSSselect("#boosh div.a", document)[0]).to.be.ok(); //found one element
 			expect(CSSselect("#boosh div", document)).to.have.length(2); //found two {div} elements
@@ -110,7 +127,7 @@ module.exports = {
 			expect(CSSselect("a.odd", document)).to.have.length(1); //found single a
 		},
 
-		"combos": function (){
+		combos: function(){
 			expect(CSSselect("#boosh div,#boosh span", document)).to.have.length(3); //found 2 divs and 1 span
 		},
 
@@ -123,23 +140,33 @@ module.exports = {
 		},
 
 		"deep messy relationships": function(){
-		// these are mostly characterised by a combination of tight relationships and loose relationships
-		// on the right side of the query it's easy to find matches but they tighten up quickly as you
-		// go to the left
-		// they are useful for making sure the dom crawler doesn't stop short or over-extend as it works
-		// up the tree the crawl needs to be comprehensive
+			// these are mostly characterised by a combination of tight relationships and loose relationships
+			// on the right side of the query it's easy to find matches but they tighten up quickly as you
+			// go to the left
+			// they are useful for making sure the dom crawler doesn't stop short or over-extend as it works
+			// up the tree the crawl needs to be comprehensive
 			expect(CSSselect("div#fixtures > div a", document)).to.have.length(5); //found four results for "div#fixtures > div a"
-			expect(CSSselect(".direct-descend > .direct-descend .lvl2", document)).to.have.length(1); //found one result for ".direct-descend > .direct-descend .lvl2"
-			expect(CSSselect(".direct-descend > .direct-descend div", document)).to.have.length(1); //found one result for ".direct-descend > .direct-descend div"
-			expect(CSSselect(".direct-descend > .direct-descend div", document)).to.have.length(1); //found one result for ".direct-descend > .direct-descend div"
+			expect(
+				CSSselect(".direct-descend > .direct-descend .lvl2", document)
+			).to.have.length(1); //found one result for ".direct-descend > .direct-descend .lvl2"
+			expect(
+				CSSselect(".direct-descend > .direct-descend div", document)
+			).to.have.length(1); //found one result for ".direct-descend > .direct-descend div"
+			expect(
+				CSSselect(".direct-descend > .direct-descend div", document)
+			).to.have.length(1); //found one result for ".direct-descend > .direct-descend div"
 			expect(CSSselect("div#fixtures div ~ a div", document)).to.be.empty(); //found no results for odd query
-			expect(CSSselect(".direct-descend > .direct-descend > .direct-descend ~ .lvl2", document)).to.be.empty(); //found no results for another odd query
+			expect(
+				CSSselect(
+					".direct-descend > .direct-descend > .direct-descend ~ .lvl2",
+					document
+				)
+			).to.be.empty(); //found no results for another odd query
 		}
 	},
 
 	"CSS 2": {
-
-		"get elements by attribute": function (){
+		"get elements by attribute": function(){
 			var wanted = CSSselect("#boosh div[test]", document)[0];
 			var expected = DomUtils.getElementById("booshTest", document);
 			expect(wanted).to.be(expected); //found attribute
@@ -148,96 +175,142 @@ module.exports = {
 			expect(CSSselect("em[nopass~=\"copyright\"]", document)).to.be.empty(); //found em[nopass~="copyright"]
 		},
 
-		"should not throw error by attribute selector": function (){
+		"should not throw error by attribute selector": function(){
 			expect(CSSselect("[foo^=\"bar\"]", document)).to.have.length(1); //found 1 element
 		},
 
-		"crazy town": function (){
+		"crazy town": function(){
 			var el = DomUtils.getElementById("attr-test3", document);
-			expect(CSSselect("div#attr-test3.found.you[title=\"whatup duders\"]", document)[0]).to.be(el); //found the right element
+			expect(
+				CSSselect(
+					"div#attr-test3.found.you[title=\"whatup duders\"]",
+					document
+				)[0]
+			).to.be(el); //found the right element
 		}
-
 	},
 
 	"attribute selectors": {
+		/* CSS 2 SPEC */
 
-	/* CSS 2 SPEC */
-
-		"[attr]": function (){
+		"[attr]": function(){
 			var expected = DomUtils.getElementById("attr-test-1", document);
-			expect(CSSselect("#attributes div[unique-test]", document)[0]).to.be(expected); //found attribute with [attr]
+			expect(CSSselect("#attributes div[unique-test]", document)[0]).to.be(
+				expected
+			); //found attribute with [attr]
 		},
 
-		"[attr=val]": function (){
+		"[attr=val]": function(){
 			var expected = DomUtils.getElementById("attr-test-2", document);
-			expect(CSSselect("#attributes div[test=\"two-foo\"]", document)[0]).to.be(expected); //found attribute with =
-			expect(CSSselect("#attributes div[test='two-foo']", document)[0]).to.be(expected); //found attribute with =
-			expect(CSSselect("#attributes div[test=two-foo]", document)[0]).to.be(expected); //found attribute with =
+			expect(CSSselect("#attributes div[test=\"two-foo\"]", document)[0]).to.be(
+				expected
+			); //found attribute with =
+			expect(CSSselect("#attributes div[test='two-foo']", document)[0]).to.be(
+				expected
+			); //found attribute with =
+			expect(CSSselect("#attributes div[test=two-foo]", document)[0]).to.be(
+				expected
+			); //found attribute with =
 		},
 
-		"[attr~=val]": function (){
+		"[attr~=val]": function(){
 			var expected = DomUtils.getElementById("attr-test-3", document);
-			expect(CSSselect("#attributes div[test~=three]", document)[0]).to.be(expected); //found attribute with ~=
+			expect(CSSselect("#attributes div[test~=three]", document)[0]).to.be(
+				expected
+			); //found attribute with ~=
 		},
 
-		"[attr|=val]": function (){
+		"[attr|=val]": function(){
 			var expected = DomUtils.getElementById("attr-test-2", document);
-			expect(CSSselect("#attributes div[test|=\"two-foo\"]", document)[0]).to.be(expected); //found attribute with |=
-			expect(CSSselect("#attributes div[test|=two]", document)[0]).to.be(expected); //found attribute with |=
+			expect(CSSselect("#attributes div[test|=\"two-foo\"]", document)[0]).to.be(
+				expected
+			); //found attribute with |=
+			expect(CSSselect("#attributes div[test|=two]", document)[0]).to.be(
+				expected
+			); //found attribute with |=
 		},
 
-		"[href=#x] special case": function (){
+		"[href=#x] special case": function(){
 			var expected = DomUtils.getElementById("attr-test-4", document);
-			expect(CSSselect("#attributes a[href=\"#aname\"]", document)[0]).to.be(expected); //found attribute with href=#x
+			expect(CSSselect("#attributes a[href=\"#aname\"]", document)[0]).to.be(
+				expected
+			); //found attribute with href=#x
 		},
 
-	/* CSS 3 SPEC */
+		/* CSS 3 SPEC */
 
-		"[attr^=val]": function (){
+		"[attr^=val]": function(){
 			var expected = DomUtils.getElementById("attr-test-2", document);
-			expect(CSSselect("#attributes div[test^=two]", document)[0]).to.be(expected); //found attribute with ^=
+			expect(CSSselect("#attributes div[test^=two]", document)[0]).to.be(
+				expected
+			); //found attribute with ^=
 		},
 
-		"[attr$=val]": function (){
+		"[attr$=val]": function(){
 			var expected = DomUtils.getElementById("attr-test-2", document);
-			expect(CSSselect("#attributes div[test$=foo]", document)[0]).to.be(expected); //found attribute with $=
+			expect(CSSselect("#attributes div[test$=foo]", document)[0]).to.be(
+				expected
+			); //found attribute with $=
 		},
 
-		"[attr*=val]": function (){
+		"[attr*=val]": function(){
 			var expected = DomUtils.getElementById("attr-test-3", document);
-			expect(CSSselect("#attributes div[test*=hree]", document)[0]).to.be(expected); //found attribute with *=
+			expect(CSSselect("#attributes div[test*=hree]", document)[0]).to.be(
+				expected
+			); //found attribute with *=
 		},
 
-		"direct descendants": function (){
-			expect(CSSselect("#direct-descend > .direct-descend", document)).to.have.length(2); //found two direct descendents
-			expect(CSSselect("#direct-descend > .direct-descend > .lvl2", document)).to.have.length(3); //found three second-level direct descendents
+		"direct descendants": function(){
+			expect(
+				CSSselect("#direct-descend > .direct-descend", document)
+			).to.have.length(2); //found two direct descendents
+			expect(
+				CSSselect("#direct-descend > .direct-descend > .lvl2", document)
+			).to.have.length(3); //found three second-level direct descendents
 		},
 
-		"sibling elements": function (){
-			expect(CSSselect("#sibling-selector ~ .sibling-selector", document)).to.have.length(2); //found two siblings
-			expect(CSSselect("#sibling-selector ~ div.sibling-selector", document)).to.have.length(2); //found two siblings
-			expect(CSSselect("#sibling-selector + div.sibling-selector", document)).to.have.length(1); //found one sibling
-			expect(CSSselect("#sibling-selector + .sibling-selector", document)).to.have.length(1); //found one sibling
+		"sibling elements": function(){
+			expect(
+				CSSselect("#sibling-selector ~ .sibling-selector", document)
+			).to.have.length(2); //found two siblings
+			expect(
+				CSSselect("#sibling-selector ~ div.sibling-selector", document)
+			).to.have.length(2); //found two siblings
+			expect(
+				CSSselect("#sibling-selector + div.sibling-selector", document)
+			).to.have.length(1); //found one sibling
+			expect(
+				CSSselect("#sibling-selector + .sibling-selector", document)
+			).to.have.length(1); //found one sibling
 
-			expect(CSSselect(".parent .oldest ~ .sibling", document)).to.have.length(4); //found four younger siblings
-			expect(CSSselect(".parent .middle ~ .sibling", document)).to.have.length(2); //found two younger siblings
+			expect(CSSselect(".parent .oldest ~ .sibling", document)).to.have.length(
+				4
+			); //found four younger siblings
+			expect(CSSselect(".parent .middle ~ .sibling", document)).to.have.length(
+				2
+			); //found two younger siblings
 			expect(CSSselect(".parent .middle ~ h4", document)).to.have.length(1); //found next sibling by tag
-			expect(CSSselect(".parent .middle ~ h4.younger", document)).to.have.length(1); //found next sibling by tag and class
+			expect(
+				CSSselect(".parent .middle ~ h4.younger", document)
+			).to.have.length(1); //found next sibling by tag and class
 			expect(CSSselect(".parent .middle ~ h3", document)).to.be.empty(); //an element can't be its own sibling
 			expect(CSSselect(".parent .middle ~ h2", document)).to.be.empty(); //didn't find an older sibling
 			expect(CSSselect(".parent .youngest ~ .sibling", document)).to.be.empty(); //found no younger siblings
 
-			expect(CSSselect(".parent .oldest + .sibling", document)).to.have.length(1); //found next sibling
-			expect(CSSselect(".parent .middle + .sibling", document)).to.have.length(1); //found next sibling
+			expect(CSSselect(".parent .oldest + .sibling", document)).to.have.length(
+				1
+			); //found next sibling
+			expect(CSSselect(".parent .middle + .sibling", document)).to.have.length(
+				1
+			); //found next sibling
 			expect(CSSselect(".parent .middle + h4", document)).to.have.length(1); //found next sibling by tag
 			expect(CSSselect(".parent .middle + h3", document)).to.be.empty(); //an element can't be its own sibling
 			expect(CSSselect(".parent .middle + h2", document)).to.be.empty(); //didn't find an older sibling
 			expect(CSSselect(".parent .youngest + .sibling", document)).to.be.empty(); //found no younger siblings
 		}
-
 	},
 
-/*
+	/*
 'Uniq': {
 	'duplicates arent found in arrays': function () {
 		expect(CSSselect.uniq(['a', 'b', 'c', 'd', 'e', 'a', 'b', 'c', 'd', 'e'])).to.have.length(5); //result should be a, b, c, d, e
@@ -246,71 +319,97 @@ module.exports = {
 },
 */
 
-
 	"element-context queries": {
-
 		"relationship-first queries": function(){
-			expect(CSSselect("> .direct-descend", CSSselect("#direct-descend", document))).to.have.length(2); //found two direct descendents using > first
-			expect(CSSselect("~ .sibling-selector", CSSselect("#sibling-selector", document))).to.have.length(2); //found two siblings with ~ first
-			expect(CSSselect("+ .sibling-selector", CSSselect("#sibling-selector", document))).to.have.length(1); //found one sibling with + first
-			expect(CSSselect("> .tokens a", CSSselect(".idless", document)[0])).to.have.length(1); //found one sibling from a root with no id
+			expect(
+				CSSselect("> .direct-descend", CSSselect("#direct-descend", document))
+			).to.have.length(2); //found two direct descendents using > first
+			expect(
+				CSSselect(
+					"~ .sibling-selector",
+					CSSselect("#sibling-selector", document)
+				)
+			).to.have.length(2); //found two siblings with ~ first
+			expect(
+				CSSselect(
+					"+ .sibling-selector",
+					CSSselect("#sibling-selector", document)
+				)
+			).to.have.length(1); //found one sibling with + first
+			expect(
+				CSSselect("> .tokens a", CSSselect(".idless", document)[0])
+			).to.have.length(1); //found one sibling from a root with no id
 		},
 
-	// should be able to query on an element that hasn't been inserted into the dom
+		// should be able to query on an element that hasn't been inserted into the dom
 		"detached fragments": function(){
 			expect(CSSselect(".a span", frag)).to.have.length(1); //should find child elements of fragment
 			expect(CSSselect("> div p em", frag)).to.have.length(2); //should find child elements of fragment, relationship first
 		},
 
-		"byId sub-queries within detached fragment": function (){
+		"byId sub-queries within detached fragment": function(){
 			expect(CSSselect("#emem", frag)).to.have.length(1); //found "#id" in fragment
 			expect(CSSselect(".d.i #emem", frag)).to.have.length(1); //found ".class.class #id" in fragment
 			expect(CSSselect(".d #oooo #emem", frag)).to.have.length(1); //found ".class #id #id" in fragment
 			expect(CSSselect("> div #oooo", frag)).to.have.length(1); //found "> .class #id" in fragment
-			expect(CSSselect("#oooo", CSSselect("#emem", frag)).length).to.not.be.ok(); //shouldn't find #oooo (ancestor) within #emem (descendent)
+			expect(
+				CSSselect("#oooo", CSSselect("#emem", frag)).length
+			).to.not.be.ok(); //shouldn't find #oooo (ancestor) within #emem (descendent)
 			expect(CSSselect("#sep", CSSselect("#emem", frag)).length).to.not.be.ok(); //shouldn't find #sep within #emem (unrelated)
 		},
 
-
 		"exclude self in match": function(){
-			expect(CSSselect(".order-matters", CSSselect("#order-matters", document)[0])).to.have.length(4); //should not include self in element-context queries
+			expect(
+				CSSselect(".order-matters", CSSselect("#order-matters", document)[0])
+			).to.have.length(4); //should not include self in element-context queries
 		},
 
-
-	// because form's have .length
+		// because form's have .length
 		"forms can be used as contexts": function(){
 			expect(CSSselect("*", CSSselect("form", document)[0])).to.have.length(3); //found 3 elements under &lt;form&gt;
 		}
 	},
 
-	"tokenizer": {
-
-		"should not get weird tokens": function (){
-			expect(CSSselect("div .tokens[title=\"one\"]", document)[0]).to.be(DomUtils.getElementById("token-one", document)); //found div .tokens[title="one"]
-			expect(CSSselect("div .tokens[title=\"one two\"]", document)[0]).to.be(DomUtils.getElementById("token-two", document)); //found div .tokens[title="one two"]
-			expect(CSSselect("div .tokens[title=\"one two three #%\"]", document)[0]).to.be(DomUtils.getElementById("token-three", document)); //found div .tokens[title="one two three #%"]
-			expect(CSSselect("div .tokens[title='one two three #%'] a", document)[0]).to.be(DomUtils.getElementById("token-four", document)); //found div .tokens[title=\'one two three #%\'] a
-			expect(CSSselect("div .tokens[title=\"one two three #%\"] a[href$=foo] div", document)[0]).to.be(DomUtils.getElementById("token-five", document)); //found div .tokens[title="one two three #%"] a[href=foo] div
+	tokenizer: {
+		"should not get weird tokens": function(){
+			expect(CSSselect("div .tokens[title=\"one\"]", document)[0]).to.be(
+				DomUtils.getElementById("token-one", document)
+			); //found div .tokens[title="one"]
+			expect(CSSselect("div .tokens[title=\"one two\"]", document)[0]).to.be(
+				DomUtils.getElementById("token-two", document)
+			); //found div .tokens[title="one two"]
+			expect(
+				CSSselect("div .tokens[title=\"one two three #%\"]", document)[0]
+			).to.be(DomUtils.getElementById("token-three", document)); //found div .tokens[title="one two three #%"]
+			expect(
+				CSSselect("div .tokens[title='one two three #%'] a", document)[0]
+			).to.be(DomUtils.getElementById("token-four", document)); //found div .tokens[title=\'one two three #%\'] a
+			expect(
+				CSSselect(
+					"div .tokens[title=\"one two three #%\"] a[href$=foo] div",
+					document
+				)[0]
+			).to.be(DomUtils.getElementById("token-five", document)); //found div .tokens[title="one two three #%"] a[href=foo] div
 		}
-
 	},
 
 	"interesting syntaxes": {
-		"should parse bad selectors": function (){
-			expect(CSSselect("#spaced-tokens    p    em    a", document).length).to.be.ok(); //found element with funny tokens
+		"should parse bad selectors": function(){
+			expect(
+				CSSselect("#spaced-tokens    p    em    a", document).length
+			).to.be.ok(); //found element with funny tokens
 		}
 	},
 
 	"order matters": {
+		// <div id="order-matters">
+		//   <p class="order-matters"></p>
+		//   <a class="order-matters">
+		//     <em class="order-matters"></em><b class="order-matters"></b>
+		//   </a>
+		// </div>
 
-	// <div id="order-matters">
-	//   <p class="order-matters"></p>
-	//   <a class="order-matters">
-	//     <em class="order-matters"></em><b class="order-matters"></b>
-	//   </a>
-	// </div>
-
-		"the order of elements return matters": function (){
+		"the order of elements return matters": function(){
 			function tag(el){
 				return el.name.toLowerCase();
 			}
@@ -320,14 +419,13 @@ module.exports = {
 			expect(tag(els[2])).to.be("em"); //first element matched is a {em} tag
 			expect(tag(els[3])).to.be("b"); //first element matched is a {b} tag
 		}
-
 	},
 
 	"pseudo-selectors": {
 		":contains": function(){
 			expect(CSSselect("li:contains(humans)", document)).to.have.length(1); //found by "element:contains(text)"
 			expect(CSSselect(":contains(humans)", document)).to.have.length(5); //found by ":contains(text)", including all ancestors
-		// * is an important case, can cause weird errors
+			// * is an important case, can cause weird errors
 			expect(CSSselect("*:contains(humans)", document)).to.have.length(5); //found by "*:contains(text)", including all ancestors
 			expect(CSSselect("ol:contains(humans)", document)).to.have.length(1); //found by "ancestor:contains(text)"
 		},
@@ -336,97 +434,157 @@ module.exports = {
 			expect(CSSselect(".odd:not(div)", document)).to.have.length(1); //found one .odd :not an &lt;a&gt;
 		},
 
-		":first-child": function (){
-			expect(CSSselect("#pseudos div:first-child", document)[0]).to.be(pseudos[0]); //found first child
+		":first-child": function(){
+			expect(CSSselect("#pseudos div:first-child", document)[0]).to.be(
+				pseudos[0]
+			); //found first child
 			expect(CSSselect("#pseudos div:first-child", document)).to.have.length(1); //found only 1
 		},
 
-		":last-child": function (){
+		":last-child": function(){
 			var all = DomUtils.getElementsByTagName("div", pseudos);
-			expect(CSSselect("#pseudos div:last-child", document)[0]).to.be(all[all.length - 1]); //found last child
+			expect(CSSselect("#pseudos div:last-child", document)[0]).to.be(
+				all[all.length - 1]
+			); //found last child
 			expect(CSSselect("#pseudos div:last-child", document)).to.have.length(1); //found only 1
 		},
 
-		"ol > li[attr=\"boosh\"]:last-child": function (){
+		"ol > li[attr=\"boosh\"]:last-child": function(){
 			var expected = DomUtils.getElementById("attr-child-boosh", document);
-			expect(CSSselect("ol > li[attr=\"boosh\"]:last-child", document)).to.have.length(1); //only 1 element found
-			expect(CSSselect("ol > li[attr=\"boosh\"]:last-child", document)[0]).to.be(expected); //found correct element
+			expect(
+				CSSselect("ol > li[attr=\"boosh\"]:last-child", document)
+			).to.have.length(1); //only 1 element found
+			expect(CSSselect("ol > li[attr=\"boosh\"]:last-child", document)[0]).to.be(
+				expected
+			); //found correct element
 		},
 
-		":nth-child(odd|even|x)": function (){
+		":nth-child(odd|even|x)": function(){
 			var second = DomUtils.getElementsByTagName("div", pseudos)[1];
 			expect(CSSselect("#pseudos :nth-child(odd)", document)).to.have.length(4); //found 4 odd elements
-			expect(CSSselect("#pseudos div:nth-child(odd)", document)).to.have.length(3); //found 3 odd elements with div tag
-			expect(CSSselect("#pseudos div:nth-child(even)", document)).to.have.length(3); //found 3 even elements with div tag
+			expect(CSSselect("#pseudos div:nth-child(odd)", document)).to.have.length(
+				3
+			); //found 3 odd elements with div tag
+			expect(
+				CSSselect("#pseudos div:nth-child(even)", document)
+			).to.have.length(3); //found 3 even elements with div tag
 			expect(CSSselect("#pseudos div:nth-child(2)", document)[0]).to.be(second); //found 2nd nth-child of pseudos
 		},
 
-		":nth-child(expr)": function (){
+		":nth-child(expr)": function(){
 			var fifth = DomUtils.getElementsByTagName("a", pseudos)[0];
 			var sixth = DomUtils.getElementsByTagName("div", pseudos)[4];
 
-			expect(CSSselect("#pseudos :nth-child(3n+1)", document)).to.have.length(3); //found 3 elements
-			expect(CSSselect("#pseudos :nth-child(+3n-2)", document)).to.have.length(3); //found 3 elements'
-			expect(CSSselect("#pseudos :nth-child(-n+6)", document)).to.have.length(6); //found 6 elements
-			expect(CSSselect("#pseudos :nth-child(-n+5)", document)).to.have.length(5); //found 5 elements
+			expect(CSSselect("#pseudos :nth-child(3n+1)", document)).to.have.length(
+				3
+			); //found 3 elements
+			expect(CSSselect("#pseudos :nth-child(+3n-2)", document)).to.have.length(
+				3
+			); //found 3 elements'
+			expect(CSSselect("#pseudos :nth-child(-n+6)", document)).to.have.length(
+				6
+			); //found 6 elements
+			expect(CSSselect("#pseudos :nth-child(-n+5)", document)).to.have.length(
+				5
+			); //found 5 elements
 			expect(CSSselect("#pseudos :nth-child(3n+2)", document)[1]).to.be(fifth); //second :nth-child(3n+2) is the fifth child
 			expect(CSSselect("#pseudos :nth-child(3n)", document)[1]).to.be(sixth); //second :nth-child(3n) is the sixth child
 		},
 
-		":nth-last-child(odd|even|x)": function (){
+		":nth-last-child(odd|even|x)": function(){
 			var second = DomUtils.getElementsByTagName("div", pseudos)[1];
-			expect(CSSselect("#pseudos :nth-last-child(odd)", document)).to.have.length(4); //found 4 odd elements
-			expect(CSSselect("#pseudos div:nth-last-child(odd)", document)).to.have.length(3); //found 3 odd elements with div tag
-			expect(CSSselect("#pseudos div:nth-last-child(even)", document)).to.have.length(3); //found 3 even elements with div tag
-			expect(CSSselect("#pseudos div:nth-last-child(6)", document)[0]).to.be(second); //6th nth-last-child should be 2nd of 7 elements
+			expect(
+				CSSselect("#pseudos :nth-last-child(odd)", document)
+			).to.have.length(4); //found 4 odd elements
+			expect(
+				CSSselect("#pseudos div:nth-last-child(odd)", document)
+			).to.have.length(3); //found 3 odd elements with div tag
+			expect(
+				CSSselect("#pseudos div:nth-last-child(even)", document)
+			).to.have.length(3); //found 3 even elements with div tag
+			expect(CSSselect("#pseudos div:nth-last-child(6)", document)[0]).to.be(
+				second
+			); //6th nth-last-child should be 2nd of 7 elements
 		},
 
-		":nth-last-child(expr)": function (){
+		":nth-last-child(expr)": function(){
 			var third = DomUtils.getElementsByTagName("div", pseudos)[2];
 
-			expect(CSSselect("#pseudos :nth-last-child(3n+1)", document)).to.have.length(3); //found 3 elements
-			expect(CSSselect("#pseudos :nth-last-child(3n-2)", document)).to.have.length(3); //found 3 elements
-			expect(CSSselect("#pseudos :nth-last-child(-n+6)", document)).to.have.length(6); //found 6 elements
-			expect(CSSselect("#pseudos :nth-last-child(-n+5)", document)).to.have.length(5); //found 5 elements
-			expect(CSSselect("#pseudos :nth-last-child(3n+2)", document)[0]).to.be(third); //first :nth-last-child(3n+2) is the third child
+			expect(
+				CSSselect("#pseudos :nth-last-child(3n+1)", document)
+			).to.have.length(3); //found 3 elements
+			expect(
+				CSSselect("#pseudos :nth-last-child(3n-2)", document)
+			).to.have.length(3); //found 3 elements
+			expect(
+				CSSselect("#pseudos :nth-last-child(-n+6)", document)
+			).to.have.length(6); //found 6 elements
+			expect(
+				CSSselect("#pseudos :nth-last-child(-n+5)", document)
+			).to.have.length(5); //found 5 elements
+			expect(CSSselect("#pseudos :nth-last-child(3n+2)", document)[0]).to.be(
+				third
+			); //first :nth-last-child(3n+2) is the third child
 		},
 
-		":nth-of-type(expr)": function (){
+		":nth-of-type(expr)": function(){
 			var a = DomUtils.getElementsByTagName("a", pseudos)[0];
 
-			expect(CSSselect("#pseudos div:nth-of-type(3n+1)", document)).to.have.length(2); //found 2 div elements
-			expect(CSSselect("#pseudos a:nth-of-type(3n+1)", document)).to.have.length(1); //found 1 a element
+			expect(
+				CSSselect("#pseudos div:nth-of-type(3n+1)", document)
+			).to.have.length(2); //found 2 div elements
+			expect(
+				CSSselect("#pseudos a:nth-of-type(3n+1)", document)
+			).to.have.length(1); //found 1 a element
 			expect(CSSselect("#pseudos a:nth-of-type(3n+1)", document)[0]).to.be(a); //found the right a element
 			expect(CSSselect("#pseudos a:nth-of-type(3n)", document)).to.be.empty(); //no matches for every third a
-			expect(CSSselect("#pseudos a:nth-of-type(odd)", document)).to.have.length(1); //found the odd a
-			expect(CSSselect("#pseudos a:nth-of-type(1)", document)).to.have.length(1); //found the first a
+			expect(CSSselect("#pseudos a:nth-of-type(odd)", document)).to.have.length(
+				1
+			); //found the odd a
+			expect(CSSselect("#pseudos a:nth-of-type(1)", document)).to.have.length(
+				1
+			); //found the first a
 		},
 
-		":nth-last-of-type(expr)": function (){
+		":nth-last-of-type(expr)": function(){
 			var second = DomUtils.getElementsByTagName("div", pseudos)[1];
 
-			expect(CSSselect("#pseudos div:nth-last-of-type(3n+1)", document)).to.have.length(2); //found 2 div elements
-			expect(CSSselect("#pseudos a:nth-last-of-type(3n+1)", document)).to.have.length(1); //found 1 a element
-			expect(CSSselect("#pseudos div:nth-last-of-type(5)", document)[0]).to.be(second); //5th nth-last-of-type should be 2nd of 7 elements
+			expect(
+				CSSselect("#pseudos div:nth-last-of-type(3n+1)", document)
+			).to.have.length(2); //found 2 div elements
+			expect(
+				CSSselect("#pseudos a:nth-last-of-type(3n+1)", document)
+			).to.have.length(1); //found 1 a element
+			expect(CSSselect("#pseudos div:nth-last-of-type(5)", document)[0]).to.be(
+				second
+			); //5th nth-last-of-type should be 2nd of 7 elements
 		},
 
-		":first-of-type": function (){
-			expect(CSSselect("#pseudos a:first-of-type", document)[0]).to.be(DomUtils.getElementsByTagName("a", pseudos)[0]); //found first a element
+		":first-of-type": function(){
+			expect(CSSselect("#pseudos a:first-of-type", document)[0]).to.be(
+				DomUtils.getElementsByTagName("a", pseudos)[0]
+			); //found first a element
 			expect(CSSselect("#pseudos a:first-of-type", document)).to.have.length(1); //found only 1
 		},
 
-		":last-of-type": function (){
+		":last-of-type": function(){
 			var all = DomUtils.getElementsByTagName("div", pseudos);
-			expect(CSSselect("#pseudos div:last-of-type", document)[0]).to.be(all[all.length - 1]); //found last div element
-			expect(CSSselect("#pseudos div:last-of-type", document)).to.have.length(1); //found only 1
+			expect(CSSselect("#pseudos div:last-of-type", document)[0]).to.be(
+				all[all.length - 1]
+			); //found last div element
+			expect(CSSselect("#pseudos div:last-of-type", document)).to.have.length(
+				1
+			); //found only 1
 		},
 
-		":only-of-type": function (){
-			expect(CSSselect("#pseudos a:only-of-type", document)[0]).to.be(DomUtils.getElementsByTagName("a", pseudos)[0]); //found the only a element
+		":only-of-type": function(){
+			expect(CSSselect("#pseudos a:only-of-type", document)[0]).to.be(
+				DomUtils.getElementsByTagName("a", pseudos)[0]
+			); //found the only a element
 			expect(CSSselect("#pseudos a:first-of-type", document)).to.have.length(1); //found only 1
 		},
 
-		":target": function (){
+		":target": function(){
 			location.hash = "";
 			expect(CSSselect("#pseudos:target", document)).to.be.empty(); //#pseudos is not the target
 			location.hash = "#pseudos";
@@ -435,13 +593,12 @@ module.exports = {
 		},
 
 		"custom pseudos": function(){
-		// :humanoid implemented just for testing purposes
+			// :humanoid implemented just for testing purposes
 			expect(CSSselect(":humanoid", document)).to.have.length(2); //selected using custom pseudo
 		}
-
 	},
 
-/*
+	/*
 'argument types': {
 
 	'should be able to pass in nodes as arguments': function () {
@@ -467,7 +624,7 @@ module.exports = {
 */
 
 	"is()": {
-		"simple selectors": function (){
+		"simple selectors": function(){
 			expect(CSSselect.is(el, "li")).to.be.ok(); //tag
 			expect(CSSselect.is(el, "*")).to.be.ok(); //wildcard
 			expect(CSSselect.is(el, "#attr-child-boosh")).to.be.ok(); //#id
@@ -478,39 +635,64 @@ module.exports = {
 			expect(CSSselect.is(el, "[foo]")).to.not.be.ok(); //wrong [attr]
 			expect(CSSselect.is(el, "[attr=foo]")).to.not.be.ok(); //wrong [attr=val]
 		},
-		"selector sequences": function (){
+		"selector sequences": function(){
 			expect(CSSselect.is(el, "li#attr-child-boosh[attr=boosh]")).to.be.ok(); //tag#id[attr=val]
-			expect(CSSselect.is(el, "div#attr-child-boosh[attr=boosh]")).to.not.be.ok(); //wrong tag#id[attr=val]
+			expect(
+				CSSselect.is(el, "div#attr-child-boosh[attr=boosh]")
+			).to.not.be.ok(); //wrong tag#id[attr=val]
 		},
-		"selector sequences combinators": function (){
+		"selector sequences combinators": function(){
 			expect(CSSselect.is(el, "ol li")).to.be.ok(); //tag tag
 			expect(CSSselect.is(el, "ol>li")).to.be.ok(); //tag>tag
 			expect(CSSselect.is(el, "ol>li+li")).to.be.ok(); //tab>tag+tag
-			expect(CSSselect.is(el, "ol#list li#attr-child-boosh[attr=boosh]")).to.be.ok(); //tag#id tag#id[attr=val]
-			expect(CSSselect.is(el, "ol#list>li#attr-child-boosh[attr=boosh]")).to.not.be.ok(); //wrong tag#id>tag#id[attr=val]
-			expect(CSSselect.is(el, "ol ol li#attr-child-boosh[attr=boosh]")).to.be.ok(); //tag tag tag#id[attr=val]
-			expect(CSSselect.is(CSSselect("#token-four", document)[0], "div#fixtures>div a")).to.be.ok(); //tag#id>tag tag where ambiguous middle tag requires backtracking
+			expect(
+				CSSselect.is(el, "ol#list li#attr-child-boosh[attr=boosh]")
+			).to.be.ok(); //tag#id tag#id[attr=val]
+			expect(
+				CSSselect.is(el, "ol#list>li#attr-child-boosh[attr=boosh]")
+			).to.not.be.ok(); //wrong tag#id>tag#id[attr=val]
+			expect(
+				CSSselect.is(el, "ol ol li#attr-child-boosh[attr=boosh]")
+			).to.be.ok(); //tag tag tag#id[attr=val]
+			expect(
+				CSSselect.is(
+					CSSselect("#token-four", document)[0],
+					"div#fixtures>div a"
+				)
+			).to.be.ok(); //tag#id>tag tag where ambiguous middle tag requires backtracking
 		},
-		"pseudos": function(){
-		//TODO: more tests!
+		pseudos: function(){
+			//TODO: more tests!
 			expect(CSSselect.is(el, "li:contains(hello)")).to.be.ok(); //matching :contains(text)
 			expect(CSSselect.is(el, "li:contains(human)")).to.not.be.ok(); //non-matching :contains(text)
-			expect(CSSselect.is(CSSselect("#list>li", document)[2], ":humanoid")).to.be.ok(); //matching custom pseudo
-			expect(CSSselect.is(CSSselect("#list>li", document)[1], ":humanoid")).to.not.be.ok(); //non-matching custom pseudo
+			expect(
+				CSSselect.is(CSSselect("#list>li", document)[2], ":humanoid")
+			).to.be.ok(); //matching custom pseudo
+			expect(
+				CSSselect.is(CSSselect("#list>li", document)[1], ":humanoid")
+			).to.not.be.ok(); //non-matching custom pseudo
 		},
-		"context": function (){
-			expect(CSSselect.is(el, "li#attr-child-boosh[attr=boosh]", {context: CSSselect("#list", document)[0]})).to.be.ok(); //context
-			expect(CSSselect.is(el, "ol#list li#attr-child-boosh[attr=boosh]", {context: CSSselect("#boosh", document)[0]})).to.not.be.ok(); //wrong context
+		context: function(){
+			expect(
+				CSSselect.is(el, "li#attr-child-boosh[attr=boosh]", {
+					context: CSSselect("#list", document)[0]
+				})
+			).to.be.ok(); //context
+			expect(
+				CSSselect.is(el, "ol#list li#attr-child-boosh[attr=boosh]", {
+					context: CSSselect("#boosh", document)[0]
+				})
+			).to.not.be.ok(); //wrong context
 		}
 	},
 
 	"selecting elements in other documents": {
-		"get element by id": function (){
+		"get element by id": function(){
 			var result = CSSselect("#hsoob", doc);
 			expect(result[0]).to.be.ok(); //found element with id=hsoob
 		},
 
-		"get elements by class": function (){
+		"get elements by class": function(){
 			expect(CSSselect("#hsoob .a", doc)).to.have.length(2); //found two elements
 			expect(CSSselect("#hsoob div.a", doc)[0]).to.be.ok(); //found one element
 			expect(CSSselect("#hsoob div", doc)).to.have.length(2); //found two {div} elements
@@ -519,29 +701,37 @@ module.exports = {
 			expect(CSSselect("p.odd", doc)).to.have.length(1); //found single br
 		},
 
-		"complex selectors": function (){
+		"complex selectors": function(){
 			expect(CSSselect(".d ~ .sib", doc)).to.have.length(2); //found one ~ sibling
 			expect(CSSselect(".a .d + .sib", doc)).to.have.length(1); //found 2 + siblings
 			expect(CSSselect("#hsoob > div > .h", doc)).to.have.length(1); //found span using child selectors
 			expect(CSSselect(".a .d ~ .sib[test=\"f g\"]", doc)).to.have.length(1); //found 1 ~ sibling with test attribute
 		},
 
-		"byId sub-queries": function (){
+		"byId sub-queries": function(){
 			expect(CSSselect("#hsoob #spanny", doc)).to.have.length(1); //found "#id #id" in frame
 			expect(CSSselect(".a #spanny", doc)).to.have.length(1); //found ".class #id" in frame
 			expect(CSSselect(".a #booshTest #spanny", doc)).to.have.length(1); //found ".class #id #id" in frame
-			expect(CSSselect("> #hsoob", doc)).to.have.length(1) //found "> #id" in frame
+			expect(CSSselect("> #hsoob", doc)).to.have.length(1); //found "> #id" in frame
 		},
 
-		"byId sub-queries within sub-context": function (){
+		"byId sub-queries within sub-context": function(){
 			expect(CSSselect("#spanny", CSSselect("#hsoob", doc))).to.have.length(1); //found "#id -> #id" in frame
-			expect(CSSselect(".a #spanny", CSSselect("#hsoob", doc))).to.have.length(1); //found ".class #id" in frame
-			expect(CSSselect(".a #booshTest #spanny", CSSselect("#hsoob", doc))).to.have.length(1); //found ".class #id #id" in frame
-			expect(CSSselect(".a > #booshTest", CSSselect("#hsoob", doc))).to.have.length(1); //found "> .class #id" in frame
-			expect(CSSselect("#booshTest", CSSselect("#spanny", doc)).length).to.not.be.ok(); //shouldn't find #booshTest (ancestor) within #spanny (descendent)
-			expect(CSSselect("#booshTest", CSSselect("#lonelyHsoob", doc)).length).to.not.be.ok(); //shouldn't find #booshTest within #lonelyHsoob (unrelated)
+			expect(CSSselect(".a #spanny", CSSselect("#hsoob", doc))).to.have.length(
+				1
+			); //found ".class #id" in frame
+			expect(
+				CSSselect(".a #booshTest #spanny", CSSselect("#hsoob", doc))
+			).to.have.length(1); //found ".class #id #id" in frame
+			expect(
+				CSSselect(".a > #booshTest", CSSselect("#hsoob", doc))
+			).to.have.length(1); //found "> .class #id" in frame
+			expect(
+				CSSselect("#booshTest", CSSselect("#spanny", doc)).length
+			).to.not.be.ok(); //shouldn't find #booshTest (ancestor) within #spanny (descendent)
+			expect(
+				CSSselect("#booshTest", CSSselect("#lonelyHsoob", doc)).length
+			).to.not.be.ok(); //shouldn't find #booshTest within #lonelyHsoob (unrelated)
 		}
-
 	}
-
 };

--- a/test/sizzle/data/testinit.js
+++ b/test/sizzle/data/testinit.js
@@ -1,11 +1,10 @@
 var assert = require("assert"),
-  decircularize = require("../../decircularize"),
+	decircularize = require("../../decircularize"),
 	helper = require("../../tools/helper.js"),
 	CSSselect = helper.CSSselect,
 	path = require("path"),
 	docPath = path.join(__dirname, "index.html"),
 	document = null;
-
 
 //in this module, the only use-case is to compare arrays of
 function deepEqual(a, b, msg){
@@ -17,11 +16,13 @@ function deepEqual(a, b, msg){
 		throw e;
 	}
 
-	function getId(n){ return n && n.attribs.id; }
+	function getId(n){
+		return n && n.attribs.id;
+	}
 }
 
 function loadDoc(){
-	return document = helper.getDocument(docPath);
+	return (document = helper.getDocument(docPath));
 }
 
 module.exports = {
@@ -60,14 +61,18 @@ function t(a, b, c){
 		i = 0;
 
 	for(; i < f.length; i++){
-		s += (s && ",") + "\"" + f[ i ].id + "\"";
+		s += (s && ",") + "\"" + f[i].id + "\"";
 	}
 
 	deepEqual(f, q.apply(q, c), a + " (" + b + ")");
 }
 
-var xmlDoc = helper.getDOMFromPath(path.join(__dirname, "fries.xml"), { xmlMode: true });
-var filtered = xmlDoc.filter(function(t){return t.type === "tag"});
+var xmlDoc = helper.getDOMFromPath(path.join(__dirname, "fries.xml"), {
+	xmlMode: true
+});
+var filtered = xmlDoc.filter(function(t){
+	return t.type === "tag";
+});
 xmlDoc.lastChild = filtered[filtered.length - 1];
 
 function createWithFriesXML(){

--- a/test/sizzle/selector.js
+++ b/test/sizzle/selector.js
@@ -14,7 +14,7 @@ var DomUtils = require("domutils"),
 	test = it,
 	decircularize = require("../decircularize");
 
-function deepEqual(e, a, m) {
+function deepEqual(e, a, m){
 	return assert.deepEqual(decircularize(e), decircularize(a), m);
 }
 
@@ -117,13 +117,19 @@ beforeEach(function(){
 test("element", function(){
 	expect(38);
 
-	var form, all, good, i, obj1, lengthtest,
-		siblingTest, iframe, html;
+	var form, all, good, i, obj1, lengthtest, siblingTest, iframe, html;
 
 	equal(Sizzle("").length, 0, "Empty selector returns an empty array");
-	deepEqual(Sizzle("div", document.createTextNode("")), [], "Text element as context fails silently");
+	deepEqual(
+		Sizzle("div", document.createTextNode("")),
+		[],
+		"Text element as context fails silently"
+	);
 	form = document.getElementById("form");
-	ok(!Sizzle.matchesSelector(form, ""), "Empty string passed to matchesSelector does not match");
+	ok(
+		!Sizzle.matchesSelector(form, ""),
+		"Empty string passed to matchesSelector does not match"
+	);
 	equal(Sizzle(" ").length, 0, "Empty selector returns an empty array");
 	equal(Sizzle("\t").length, 0, "Empty selector returns an empty array");
 
@@ -138,52 +144,181 @@ test("element", function(){
 	ok(good, "Select all elements, no comment nodes");
 	t("Element Selector", "html", ["html"]);
 	t("Element Selector", "body", ["body"]);
-	t("Element Selector", "#qunit-fixture p", ["firstp","ap","sndp","en","sap","first"]);
+	t("Element Selector", "#qunit-fixture p", [
+		"firstp",
+		"ap",
+		"sndp",
+		"en",
+		"sap",
+		"first"
+	]);
 
-	t("Leading space", " #qunit-fixture p", ["firstp","ap","sndp","en","sap","first"]);
-	t("Leading tab", "\t#qunit-fixture p", ["firstp","ap","sndp","en","sap","first"]);
-	t("Leading carriage return", "\r#qunit-fixture p", ["firstp","ap","sndp","en","sap","first"]);
-	t("Leading line feed", "\n#qunit-fixture p", ["firstp","ap","sndp","en","sap","first"]);
-	t("Leading form feed", "\f#qunit-fixture p", ["firstp","ap","sndp","en","sap","first"]);
-	t("Trailing space", "#qunit-fixture p ", ["firstp","ap","sndp","en","sap","first"]);
-	t("Trailing tab", "#qunit-fixture p\t", ["firstp","ap","sndp","en","sap","first"]);
-	t("Trailing carriage return", "#qunit-fixture p\r", ["firstp","ap","sndp","en","sap","first"]);
-	t("Trailing line feed", "#qunit-fixture p\n", ["firstp","ap","sndp","en","sap","first"]);
-	t("Trailing form feed", "#qunit-fixture p\f", ["firstp","ap","sndp","en","sap","first"]);
+	t("Leading space", " #qunit-fixture p", [
+		"firstp",
+		"ap",
+		"sndp",
+		"en",
+		"sap",
+		"first"
+	]);
+	t("Leading tab", "\t#qunit-fixture p", [
+		"firstp",
+		"ap",
+		"sndp",
+		"en",
+		"sap",
+		"first"
+	]);
+	t("Leading carriage return", "\r#qunit-fixture p", [
+		"firstp",
+		"ap",
+		"sndp",
+		"en",
+		"sap",
+		"first"
+	]);
+	t("Leading line feed", "\n#qunit-fixture p", [
+		"firstp",
+		"ap",
+		"sndp",
+		"en",
+		"sap",
+		"first"
+	]);
+	t("Leading form feed", "\f#qunit-fixture p", [
+		"firstp",
+		"ap",
+		"sndp",
+		"en",
+		"sap",
+		"first"
+	]);
+	t("Trailing space", "#qunit-fixture p ", [
+		"firstp",
+		"ap",
+		"sndp",
+		"en",
+		"sap",
+		"first"
+	]);
+	t("Trailing tab", "#qunit-fixture p\t", [
+		"firstp",
+		"ap",
+		"sndp",
+		"en",
+		"sap",
+		"first"
+	]);
+	t("Trailing carriage return", "#qunit-fixture p\r", [
+		"firstp",
+		"ap",
+		"sndp",
+		"en",
+		"sap",
+		"first"
+	]);
+	t("Trailing line feed", "#qunit-fixture p\n", [
+		"firstp",
+		"ap",
+		"sndp",
+		"en",
+		"sap",
+		"first"
+	]);
+	t("Trailing form feed", "#qunit-fixture p\f", [
+		"firstp",
+		"ap",
+		"sndp",
+		"en",
+		"sap",
+		"first"
+	]);
 
 	t("Parent Element", "dl ol", ["empty", "listWithTabIndex"]);
-	t("Parent Element (non-space descendant combinator)", "dl\tol", ["empty", "listWithTabIndex"]);
+	t("Parent Element (non-space descendant combinator)", "dl\tol", [
+		"empty",
+		"listWithTabIndex"
+	]);
 	obj1 = document.getElementById("object1");
 	equal(Sizzle("param", obj1).length, 2, "Object/param as context");
 
-	deepEqual(Sizzle("select", form), q("select1","select2","select3","select4","select5"), "Finding selects with a context.");
+	deepEqual(
+		Sizzle("select", form),
+		q("select1", "select2", "select3", "select4", "select5"),
+		"Finding selects with a context."
+	);
 
 	// Check for unique-ness and sort order
 	deepEqual(Sizzle("p, div p"), Sizzle("p"), "Check for duplicates: p, div p");
 
-	t("Checking sort order", "h2, h1", ["qunit-header", "qunit-banner", "qunit-userAgent"]);
+	t("Checking sort order", "h2, h1", [
+		"qunit-header",
+		"qunit-banner",
+		"qunit-userAgent"
+	]);
 	//  t( "Checking sort order", "h2:first, h1:first", ["qunit-header", "qunit-banner"] );
-	t("Checking sort order", "#qunit-fixture p, #qunit-fixture p a", ["firstp", "simon1", "ap", "google", "groups", "anchor1", "mark", "sndp", "en", "yahoo", "sap", "anchor2", "simon", "first"]);
+	t("Checking sort order", "#qunit-fixture p, #qunit-fixture p a", [
+		"firstp",
+		"simon1",
+		"ap",
+		"google",
+		"groups",
+		"anchor1",
+		"mark",
+		"sndp",
+		"en",
+		"yahoo",
+		"sap",
+		"anchor2",
+		"simon",
+		"first"
+	]);
 
 	// Test Conflict ID
 	lengthtest = document.getElementById("lengthtest");
-	deepEqual(Sizzle("#idTest", lengthtest), q("idTest"), "Finding element with id of ID.");
-	deepEqual(Sizzle("[name='id']", lengthtest), q("idTest"), "Finding element with id of ID.");
-	deepEqual(Sizzle("input[id='idTest']", lengthtest), q("idTest"), "Finding elements with id of ID.");
+	deepEqual(
+		Sizzle("#idTest", lengthtest),
+		q("idTest"),
+		"Finding element with id of ID."
+	);
+	deepEqual(
+		Sizzle("[name='id']", lengthtest),
+		q("idTest"),
+		"Finding element with id of ID."
+	);
+	deepEqual(
+		Sizzle("input[id='idTest']", lengthtest),
+		q("idTest"),
+		"Finding elements with id of ID."
+	);
 
 	siblingTest = document.getElementById("siblingTest"); // TODO
-	deepEqual(Sizzle("div em", siblingTest), [], "Element-rooted QSA does not select based on document context");
-	deepEqual(Sizzle("div em, div em, div em:not(div em)", siblingTest), [], "Element-rooted QSA does not select based on document context");
-	deepEqual(Sizzle("div em, em\\,", siblingTest), [], "Escaped commas do not get treated with an id in element-rooted QSA");
+	deepEqual(
+		Sizzle("div em", siblingTest),
+		[],
+		"Element-rooted QSA does not select based on document context"
+	);
+	deepEqual(
+		Sizzle("div em, div em, div em:not(div em)", siblingTest),
+		[],
+		"Element-rooted QSA does not select based on document context"
+	);
+	deepEqual(
+		Sizzle("div em, em\\,", siblingTest),
+		[],
+		"Escaped commas do not get treated with an id in element-rooted QSA"
+	);
 
 	iframe = document.getElementById("iframe");
 	//iframeDoc.open();
 	iframe.children = helper.getDOM("<body><p id='foo'>bar</p></body>");
-	iframe.children.forEach(function(e){ e.parent = iframe; });
+	iframe.children.forEach(function(e){
+		e.parent = iframe;
+	});
 	//iframeDoc.close();
 	deepEqual(
 		Sizzle("p:contains(bar)", iframe),
-		[ DomUtils.getElementById("foo", iframe.children) ],
+		[DomUtils.getElementById("foo", iframe.children)],
 		"Other document as context"
 	);
 	iframe.children = [];
@@ -193,8 +328,14 @@ test("element", function(){
 		html = "<div>" + html + "</div>";
 	}
 	html = jQuery(html).appendTo(document.body);
-	ok(!!Sizzle("body div div div").length, "No stack or performance problems with large amounts of descendents");
-	ok(!!Sizzle("body>div div div").length, "No stack or performance problems with large amounts of descendents");
+	ok(
+		!!Sizzle("body div div div").length,
+		"No stack or performance problems with large amounts of descendents"
+	);
+	ok(
+		!!Sizzle("body>div div div").length,
+		"No stack or performance problems with large amounts of descendents"
+	);
 	html.remove();
 
 	// Real use case would be using .watch in browsers with window.watch (see Issue #157)
@@ -202,7 +343,9 @@ test("element", function(){
 	elem.attribs.id = "toString";
 	var siblings = q("qunit-fixture")[0].children;
 	siblings.push(elem);
-	t("Element name matches Object.prototype property", "tostring#toString", ["toString"]);
+	t("Element name matches Object.prototype property", "tostring#toString", [
+		"toString"
+	]);
 	siblings.pop();
 });
 
@@ -212,31 +355,64 @@ test("XML Document Selectors", function(){
 
 	equal(Sizzle("foo_bar", xml).length, 1, "Element Selector with underscore");
 	equal(Sizzle(".component", xml).length, 1, "Class selector");
-	equal(Sizzle("[class*=component]", xml).length, 1, "Attribute selector for class");
-	equal(Sizzle("property[name=prop2]", xml).length, 1, "Attribute selector with name");
+	equal(
+		Sizzle("[class*=component]", xml).length,
+		1,
+		"Attribute selector for class"
+	);
+	equal(
+		Sizzle("property[name=prop2]", xml).length,
+		1,
+		"Attribute selector with name"
+	);
 	equal(Sizzle("[name=prop2]", xml).length, 1, "Attribute selector with name");
 	equal(Sizzle("#seite1", xml).length, 1, "Attribute selector with ID");
-	equal(Sizzle("component#seite1", xml).length, 1, "Attribute selector with ID");
-	equal(Sizzle.matches("#seite1", Sizzle("component", xml)).length, 1, "Attribute selector filter with ID");
-	equal(Sizzle("meta property thing", xml).length, 2, "Descendent selector and dir caching");
-	ok(Sizzle.matchesSelector(xml.lastChild, "soap\\:Envelope", { xmlMode: true }), "Check for namespaced element");
+	equal(
+		Sizzle("component#seite1", xml).length,
+		1,
+		"Attribute selector with ID"
+	);
+	equal(
+		Sizzle.matches("#seite1", Sizzle("component", xml)).length,
+		1,
+		"Attribute selector filter with ID"
+	);
+	equal(
+		Sizzle("meta property thing", xml).length,
+		2,
+		"Descendent selector and dir caching"
+	);
+	ok(
+		Sizzle.matchesSelector(xml.lastChild, "soap\\:Envelope", { xmlMode: true }),
+		"Check for namespaced element"
+	);
 
-	xml = helper.getDOM("<?xml version='1.0' encoding='UTF-8'?><root><elem id='1'/></root>", { xmlMode: true });
-	equal(Sizzle("elem:not(:has(*))", xml).length, 1,
-		"Non-qSA path correctly handles numeric ids (jQuery #14142)");
+	xml = helper.getDOM(
+		"<?xml version='1.0' encoding='UTF-8'?><root><elem id='1'/></root>",
+		{ xmlMode: true }
+	);
+	equal(
+		Sizzle("elem:not(:has(*))", xml).length,
+		1,
+		"Non-qSA path correctly handles numeric ids (jQuery #14142)"
+	);
 });
 
 test("broken", function(){
 	expect(26);
 
 	var broken = function(name, selector){
-		raises(function(){
+		raises(
+			function(){
 				// Setting context to null here somehow avoids QUnit's window.error handling
 				// making the e & e.message correct
 				// For whatever reason, without this,
 				// Sizzle.error will be called but no error will be seen in oldIE
-			Sizzle.call(null, selector);
-		}, Error, name + ": " + selector);
+				Sizzle.call(null, selector);
+			},
+			Error,
+			name + ": " + selector
+		);
 	};
 
 	broken("Broken Selector", "[");
@@ -273,7 +449,9 @@ test("broken", function(){
 	broken("Only-last-child", ":only-last-child");
 
 	// Make sure attribute value quoting works correctly. See: #6093
-	jQuery("<input type='hidden' value='2' name='foo.baz' id='attrbad1'/><input type='hidden' value='2' name='foo[baz]' id='attrbad2'/>").appendTo("#qunit-fixture");
+	jQuery(
+		"<input type='hidden' value='2' name='foo.baz' id='attrbad1'/><input type='hidden' value='2' name='foo[baz]' id='attrbad2'/>"
+	).appendTo("#qunit-fixture");
 
 	broken("Attribute not escaped", "input[name=foo.baz]", []);
 	// Shouldn't be matching those inner brackets
@@ -291,19 +469,26 @@ test("id", function(){
 	t("ID selector with existing ID descendant", "#firstp #simon1", ["simon1"]);
 	t("ID selector with non-existant descendant", "#firstp #foobar", []);
 	t("ID selector using UTF8", "#台北Táiběi", ["台北Táiběi"]);
-	t("Multiple ID selectors using UTF8", "#台北Táiběi, #台北", ["台北Táiběi","台北"]);
+	t("Multiple ID selectors using UTF8", "#台北Táiběi, #台北", [
+		"台北Táiběi",
+		"台北"
+	]);
 	t("Descendant ID selector using UTF8", "div #台北", ["台北"]);
 	t("Child ID selector using UTF8", "form > #台北", ["台北"]);
 
 	t("Escaped ID", "#foo\\:bar", ["foo:bar"]);
-	t("Escaped ID with descendent", "#foo\\:bar span:not(:input)", ["foo_descendent"]);
+	t("Escaped ID with descendent", "#foo\\:bar span:not(:input)", [
+		"foo_descendent"
+	]);
 	t("Escaped ID", "#test\\.foo\\[5\\]bar", ["test.foo[5]bar"]);
 	t("Descendant escaped ID", "div #foo\\:bar", ["foo:bar"]);
 	t("Descendant escaped ID", "div #test\\.foo\\[5\\]bar", ["test.foo[5]bar"]);
 	t("Child escaped ID", "form > #foo\\:bar", ["foo:bar"]);
 	t("Child escaped ID", "form > #test\\.foo\\[5\\]bar", ["test.foo[5]bar"]);
 
-	fiddle = jQuery("<div id='fiddle\\Foo'><span id='fiddleSpan'></span></div>").appendTo("#qunit-fixture");
+	fiddle = jQuery(
+		"<div id='fiddle\\Foo'><span id='fiddleSpan'></span></div>"
+	).appendTo("#qunit-fixture");
 	//  deepEqual( Sizzle( "> span", Sizzle("#fiddle\\\\Foo")[0] ), q([ "fiddleSpan" ]), "Escaped ID as context" );
 	fiddle.remove();
 
@@ -314,20 +499,42 @@ test("id", function(){
 	t("All Children of ID", "#foo > *", ["sndp", "en", "sap"]);
 	t("All Children of ID with no children", "#firstUL > *", []);
 
-	equal(Sizzle("#tName1")[0].attribs.id, "tName1", "ID selector with same value for a name attribute");
-	t("ID selector non-existing but name attribute on an A tag",         "#tName2",      []);
-	t("Leading ID selector non-existing but name attribute on an A tag", "#tName2 span", []);
-	t("Leading ID selector existing, retrieving the child",              "#tName1 span", ["tName1-span"]);
-	equal(Sizzle("div > div #tName1")[0].attribs.id, Sizzle("#tName1-span")[0].parent.attribs.id, "Ending with ID");
+	equal(
+		Sizzle("#tName1")[0].attribs.id,
+		"tName1",
+		"ID selector with same value for a name attribute"
+	);
+	t("ID selector non-existing but name attribute on an A tag", "#tName2", []);
+	t(
+		"Leading ID selector non-existing but name attribute on an A tag",
+		"#tName2 span",
+		[]
+	);
+	t("Leading ID selector existing, retrieving the child", "#tName1 span", [
+		"tName1-span"
+	]);
+	equal(
+		Sizzle("div > div #tName1")[0].attribs.id,
+		Sizzle("#tName1-span")[0].parent.attribs.id,
+		"Ending with ID"
+	);
 
 	jQuery("<a id='backslash\\foo'></a>").appendTo("#qunit-fixture");
 	t("ID Selector contains backslash", "#backslash\\\\foo", ["backslash\\foo"]);
 
-	t("ID Selector on Form with an input that has a name of 'id'", "#lengthtest", ["lengthtest"]);
+	t(
+		"ID Selector on Form with an input that has a name of 'id'",
+		"#lengthtest",
+		["lengthtest"]
+	);
 
 	t("ID selector with non-existant ancestor", "#asdfasdf #foobar", []); // bug #986
 
-	deepEqual(Sizzle("div#form", document.body), [], "ID selector within the context of another element");
+	deepEqual(
+		Sizzle("div#form", document.body),
+		[],
+		"ID selector within the context of another element"
+	);
 
 	t("Underscore ID", "#types_all", ["types_all"]);
 	t("Dash ID", "#qunit-fixture", ["qunit-fixture"]);
@@ -338,50 +545,82 @@ test("id", function(){
 test("class", function(){
 	expect(26);
 
-	t("Class Selector", ".blog", ["mark","simon"]);
+	t("Class Selector", ".blog", ["mark", "simon"]);
 	t("Class Selector", ".GROUPS", ["groups"]);
 	t("Class Selector", ".blog.link", ["simon"]);
-	t("Class Selector w/ Element", "a.blog", ["mark","simon"]);
-	t("Parent Class Selector", "p .blog", ["mark","simon"]);
+	t("Class Selector w/ Element", "a.blog", ["mark", "simon"]);
+	t("Parent Class Selector", "p .blog", ["mark", "simon"]);
 
 	t("Class selector using UTF8", ".台北Táiběi", ["utf8class1"]);
-	t("Class selector using UTF8", ".台北", ["utf8class1","utf8class2"]);
+	t("Class selector using UTF8", ".台北", ["utf8class1", "utf8class2"]);
 	t("Class selector using UTF8", ".台北Táiběi.台北", ["utf8class1"]);
-	t("Class selector using UTF8", ".台北Táiběi, .台北", ["utf8class1","utf8class2"]);
+	t("Class selector using UTF8", ".台北Táiběi, .台北", [
+		"utf8class1",
+		"utf8class2"
+	]);
 	t("Descendant class selector using UTF8", "div .台北Táiběi", ["utf8class1"]);
 	t("Child class selector using UTF8", "form > .台北Táiběi", ["utf8class1"]);
 
 	t("Escaped Class", ".foo\\:bar", ["foo:bar"]);
 	t("Escaped Class", ".test\\.foo\\[5\\]bar", ["test.foo[5]bar"]);
 	t("Descendant escaped Class", "div .foo\\:bar", ["foo:bar"]);
-	t("Descendant escaped Class", "div .test\\.foo\\[5\\]bar", ["test.foo[5]bar"]);
+	t("Descendant escaped Class", "div .test\\.foo\\[5\\]bar", [
+		"test.foo[5]bar"
+	]);
 	t("Child escaped Class", "form > .foo\\:bar", ["foo:bar"]);
 	t("Child escaped Class", "form > .test\\.foo\\[5\\]bar", ["test.foo[5]bar"]);
 
 	var div = document.createElement("div");
-	div.children = helper.getDOM("<div class='test e'></div><div class='test'></div>");
+	div.children = helper.getDOM(
+		"<div class='test e'></div><div class='test'></div>"
+	);
 	div.children.forEach(function(e){
 		e.parent = div;
 	});
-	deepEqual(Sizzle(".e", div), [ div.children[0] ], "Finding a second class.");
+	deepEqual(Sizzle(".e", div), [div.children[0]], "Finding a second class.");
 
 	var lastChild = div.children[div.children.length - 1];
 	lastChild.attribs.class = "e";
 
-	deepEqual(Sizzle(".e", div), [ div.children[0], lastChild ], "Finding a modified class.");
+	deepEqual(
+		Sizzle(".e", div),
+		[div.children[0], lastChild],
+		"Finding a modified class."
+	);
 
-	ok(!Sizzle.matchesSelector(div, ".null"), ".null does not match an element with no class");
-	ok(!Sizzle.matchesSelector(div.children[0], ".null div"), ".null does not match an element with no class");
+	ok(
+		!Sizzle.matchesSelector(div, ".null"),
+		".null does not match an element with no class"
+	);
+	ok(
+		!Sizzle.matchesSelector(div.children[0], ".null div"),
+		".null does not match an element with no class"
+	);
 	div.attribs.class = "null";
-	ok(Sizzle.matchesSelector(div, ".null"), ".null matches element with class 'null'");
-	ok(Sizzle.matchesSelector(div.children[0], ".null div"), "caching system respects DOM changes");
-	ok(!Sizzle.matchesSelector(document, ".foo"), "testing class on document doesn't error");
+	ok(
+		Sizzle.matchesSelector(div, ".null"),
+		".null matches element with class 'null'"
+	);
+	ok(
+		Sizzle.matchesSelector(div.children[0], ".null div"),
+		"caching system respects DOM changes"
+	);
+	ok(
+		!Sizzle.matchesSelector(document, ".foo"),
+		"testing class on document doesn't error"
+	);
 	//ok( !Sizzle.matchesSelector( window, ".foo" ), "testing class on window doesn't error" );
 
 	lastChild.attribs.class += " hasOwnProperty toString";
-	deepEqual(Sizzle(".e.hasOwnProperty.toString", div), [ lastChild ], "Classes match Object.prototype properties");
+	deepEqual(
+		Sizzle(".e.hasOwnProperty.toString", div),
+		[lastChild],
+		"Classes match Object.prototype properties"
+	);
 
-	div = jQuery("<div><svg width='200' height='250' version='1.1' xmlns='http://www.w3.org/2000/svg'><rect x='10' y='10' width='30' height='30' class='foo'></rect></svg></div>")[0];
+	div = jQuery(
+		"<div><svg width='200' height='250' version='1.1' xmlns='http://www.w3.org/2000/svg'><rect x='10' y='10' width='30' height='30' class='foo'></rect></svg></div>"
+	)[0];
 	equal(Sizzle(".foo", div).length, 1, "Class selector against SVG");
 });
 
@@ -398,14 +637,30 @@ test("name", function(){
 	t("Name selector non-input", "[name=div]", ["name-is-div"]);
 	t("Name selector non-input", "*[name=iframe]", ["iframe"]);
 
-	t("Name selector for grouped input", "input[name='types[]']", ["types_all", "types_anime", "types_movie"]);
+	t("Name selector for grouped input", "input[name='types[]']", [
+		"types_all",
+		"types_anime",
+		"types_movie"
+	]);
 
 	form = document.getElementById("form");
-	deepEqual(Sizzle("input[name=action]", form), q("text1"), "Name selector within the context of another element");
-	deepEqual(Sizzle("input[name='foo[bar]']", form), q("hidden2"), "Name selector for grouped form element within the context of another element");
+	deepEqual(
+		Sizzle("input[name=action]", form),
+		q("text1"),
+		"Name selector within the context of another element"
+	);
+	deepEqual(
+		Sizzle("input[name='foo[bar]']", form),
+		q("hidden2"),
+		"Name selector for grouped form element within the context of another element"
+	);
 
 	form = jQuery("<form><input name='id'/></form>").appendTo("body");
-	equal(Sizzle("input", form[0]).length, 1, "Make sure that rooted queries on forms (with possible expandos) work.");
+	equal(
+		Sizzle("input", form[0]).length,
+		1,
+		"Make sure that rooted queries on forms (with possible expandos) work."
+	);
 
 	form.remove();
 
@@ -417,12 +672,66 @@ test("name", function(){
 test("multiple", function(){
 	expect(6);
 
-	t("Comma Support", "h2, #qunit-fixture p", ["qunit-banner","qunit-userAgent","firstp","ap","sndp","en","sap","first"]);
-	t("Comma Support", "h2 , #qunit-fixture p", ["qunit-banner","qunit-userAgent","firstp","ap","sndp","en","sap","first"]);
-	t("Comma Support", "h2 , #qunit-fixture p", ["qunit-banner","qunit-userAgent","firstp","ap","sndp","en","sap","first"]);
-	t("Comma Support", "h2,#qunit-fixture p", ["qunit-banner","qunit-userAgent","firstp","ap","sndp","en","sap","first"]);
-	t("Comma Support", "h2,#qunit-fixture p ", ["qunit-banner","qunit-userAgent","firstp","ap","sndp","en","sap","first"]);
-	t("Comma Support", "h2\t,\r#qunit-fixture p\n", ["qunit-banner","qunit-userAgent","firstp","ap","sndp","en","sap","first"]);
+	t("Comma Support", "h2, #qunit-fixture p", [
+		"qunit-banner",
+		"qunit-userAgent",
+		"firstp",
+		"ap",
+		"sndp",
+		"en",
+		"sap",
+		"first"
+	]);
+	t("Comma Support", "h2 , #qunit-fixture p", [
+		"qunit-banner",
+		"qunit-userAgent",
+		"firstp",
+		"ap",
+		"sndp",
+		"en",
+		"sap",
+		"first"
+	]);
+	t("Comma Support", "h2 , #qunit-fixture p", [
+		"qunit-banner",
+		"qunit-userAgent",
+		"firstp",
+		"ap",
+		"sndp",
+		"en",
+		"sap",
+		"first"
+	]);
+	t("Comma Support", "h2,#qunit-fixture p", [
+		"qunit-banner",
+		"qunit-userAgent",
+		"firstp",
+		"ap",
+		"sndp",
+		"en",
+		"sap",
+		"first"
+	]);
+	t("Comma Support", "h2,#qunit-fixture p ", [
+		"qunit-banner",
+		"qunit-userAgent",
+		"firstp",
+		"ap",
+		"sndp",
+		"en",
+		"sap",
+		"first"
+	]);
+	t("Comma Support", "h2\t,\r#qunit-fixture p\n", [
+		"qunit-banner",
+		"qunit-userAgent",
+		"firstp",
+		"ap",
+		"sndp",
+		"en",
+		"sap",
+		"first"
+	]);
 });
 
 test("child and adjacent", function(){
@@ -430,49 +739,119 @@ test("child and adjacent", function(){
 
 	var siblingFirst, en;
 
-	t("Child", "p > a", ["simon1","google","groups","mark","yahoo","simon"]);
-	t("Child", "p> a", ["simon1","google","groups","mark","yahoo","simon"]);
-	t("Child", "p >a", ["simon1","google","groups","mark","yahoo","simon"]);
-	t("Child", "p>a", ["simon1","google","groups","mark","yahoo","simon"]);
-	t("Child w/ Class", "p > a.blog", ["mark","simon"]);
-	t("All Children", "code > *", ["anchor1","anchor2"]);
-	t("All Grandchildren", "p > * > *", ["anchor1","anchor2"]);
+	t("Child", "p > a", ["simon1", "google", "groups", "mark", "yahoo", "simon"]);
+	t("Child", "p> a", ["simon1", "google", "groups", "mark", "yahoo", "simon"]);
+	t("Child", "p >a", ["simon1", "google", "groups", "mark", "yahoo", "simon"]);
+	t("Child", "p>a", ["simon1", "google", "groups", "mark", "yahoo", "simon"]);
+	t("Child w/ Class", "p > a.blog", ["mark", "simon"]);
+	t("All Children", "code > *", ["anchor1", "anchor2"]);
+	t("All Grandchildren", "p > * > *", ["anchor1", "anchor2"]);
 	t("Adjacent", "#qunit-fixture a + a", ["groups", "tName2ID"]);
 	t("Adjacent", "#qunit-fixture a +a", ["groups", "tName2ID"]);
 	t("Adjacent", "#qunit-fixture a+ a", ["groups", "tName2ID"]);
 	t("Adjacent", "#qunit-fixture a+a", ["groups", "tName2ID"]);
-	t("Adjacent", "p + p", ["ap","en","sap"]);
+	t("Adjacent", "p + p", ["ap", "en", "sap"]);
 	t("Adjacent", "p#firstp + p", ["ap"]);
 	t("Adjacent", "p[lang=en] + p", ["sap"]);
 	t("Adjacent", "a.GROUPS + code + a", ["mark"]);
-	t("Comma, Child, and Adjacent", "#qunit-fixture a + a, code > a", ["groups","anchor1","anchor2","tName2ID"]);
-	t("Element Preceded By", "#qunit-fixture p ~ div", ["foo", "nothiddendiv", "moretests","tabindex-tests", "liveHandlerOrder", "siblingTest"]);
-	t("Element Preceded By", "#first ~ div", ["moretests","tabindex-tests", "liveHandlerOrder", "siblingTest"]);
+	t("Comma, Child, and Adjacent", "#qunit-fixture a + a, code > a", [
+		"groups",
+		"anchor1",
+		"anchor2",
+		"tName2ID"
+	]);
+	t("Element Preceded By", "#qunit-fixture p ~ div", [
+		"foo",
+		"nothiddendiv",
+		"moretests",
+		"tabindex-tests",
+		"liveHandlerOrder",
+		"siblingTest"
+	]);
+	t("Element Preceded By", "#first ~ div", [
+		"moretests",
+		"tabindex-tests",
+		"liveHandlerOrder",
+		"siblingTest"
+	]);
 	t("Element Preceded By", "#groups ~ a", ["mark"]);
 	t("Element Preceded By", "#length ~ input", ["idTest"]);
-	t("Element Preceded By", "#siblingfirst ~ em", ["siblingnext", "siblingthird"]);
-	t("Element Preceded By (multiple)", "#siblingTest em ~ em ~ em ~ span", ["siblingspan"]);
-	t("Element Preceded By, Containing", "#liveHandlerOrder ~ div em:contains('1')", ["siblingfirst"]);
+	t("Element Preceded By", "#siblingfirst ~ em", [
+		"siblingnext",
+		"siblingthird"
+	]);
+	t("Element Preceded By (multiple)", "#siblingTest em ~ em ~ em ~ span", [
+		"siblingspan"
+	]);
+	t(
+		"Element Preceded By, Containing",
+		"#liveHandlerOrder ~ div em:contains('1')",
+		["siblingfirst"]
+	);
 
 	siblingFirst = document.getElementById("siblingfirst");
 
-	deepEqual(Sizzle("~ em", siblingFirst), q("siblingnext", "siblingthird"), "Element Preceded By with a context.");
-	deepEqual(Sizzle("+ em", siblingFirst), q("siblingnext"), "Element Directly Preceded By with a context.");
+	deepEqual(
+		Sizzle("~ em", siblingFirst),
+		q("siblingnext", "siblingthird"),
+		"Element Preceded By with a context."
+	);
+	deepEqual(
+		Sizzle("+ em", siblingFirst),
+		q("siblingnext"),
+		"Element Directly Preceded By with a context."
+	);
 	//deepEqual( Sizzle("~ em:first", siblingFirst), q("siblingnext"), "Element Preceded By positional with a context." );
 
 	en = document.getElementById("en");
-	deepEqual(Sizzle("+ p, a", en), q("yahoo", "sap"), "Compound selector with context, beginning with sibling test.");
-	deepEqual(Sizzle("a, + p", en), q("yahoo", "sap"), "Compound selector with context, containing sibling test.");
+	deepEqual(
+		Sizzle("+ p, a", en),
+		q("yahoo", "sap"),
+		"Compound selector with context, beginning with sibling test."
+	);
+	deepEqual(
+		Sizzle("a, + p", en),
+		q("yahoo", "sap"),
+		"Compound selector with context, containing sibling test."
+	);
 
-	t("Multiple combinators selects all levels", "#siblingTest em *", ["siblingchild", "siblinggrandchild", "siblinggreatgrandchild"]);
-	t("Multiple combinators selects all levels", "#siblingTest > em *", ["siblingchild", "siblinggrandchild", "siblinggreatgrandchild"]);
-	t("Multiple sibling combinators doesn't miss general siblings", "#siblingTest > em:first-child + em ~ span", ["siblingspan"]);
-	t("Combinators are not skipped when mixing general and specific", "#siblingTest > em:contains('x') + em ~ span", []);
+	t("Multiple combinators selects all levels", "#siblingTest em *", [
+		"siblingchild",
+		"siblinggrandchild",
+		"siblinggreatgrandchild"
+	]);
+	t("Multiple combinators selects all levels", "#siblingTest > em *", [
+		"siblingchild",
+		"siblinggrandchild",
+		"siblinggreatgrandchild"
+	]);
+	t(
+		"Multiple sibling combinators doesn't miss general siblings",
+		"#siblingTest > em:first-child + em ~ span",
+		["siblingspan"]
+	);
+	t(
+		"Combinators are not skipped when mixing general and specific",
+		"#siblingTest > em:contains('x') + em ~ span",
+		[]
+	);
 
-	equal(Sizzle("#listWithTabIndex").length, 1, "Parent div for next test is found via ID (#8310)");
+	equal(
+		Sizzle("#listWithTabIndex").length,
+		1,
+		"Parent div for next test is found via ID (#8310)"
+	);
 	//equal( Sizzle("#listWithTabIndex li:eq(2) ~ li").length, 1, "Find by general sibling combinator (#8310)" );
-	equal(Sizzle("#__sizzle__").length, 0, "Make sure the temporary id assigned by sizzle is cleared out (#8310)");
-	equal(Sizzle("#listWithTabIndex").length, 1, "Parent div for previous test is still found via ID (#8310)");
+	equal(
+		Sizzle("#__sizzle__").length,
+		0,
+		"Make sure the temporary id assigned by sizzle is cleared out (#8310)"
+	);
+	equal(
+		Sizzle("#listWithTabIndex").length,
+		1,
+		"Parent div for previous test is still found via ID (#8310)"
+	);
 
 	t("Verify deep class selector", "div.blah > p > a", []);
 
@@ -491,21 +870,35 @@ test("attributes", function(){
 	var opt, input, attrbad, div;
 
 	t("Attribute Exists", "#qunit-fixture a[title]", ["google"]);
-	t("Attribute Exists (case-insensitive)", "#qunit-fixture a[TITLE]", ["google"]);
+	t("Attribute Exists (case-insensitive)", "#qunit-fixture a[TITLE]", [
+		"google"
+	]);
 	t("Attribute Exists", "#qunit-fixture *[title]", ["google"]);
 	t("Attribute Exists", "#qunit-fixture [title]", ["google"]);
 	t("Attribute Exists", "#qunit-fixture a[ title ]", ["google"]);
 
 	t("Boolean attribute exists", "#select2 option[selected]", ["option2d"]);
-	t("Boolean attribute equals", "#select2 option[selected='selected']", ["option2d"]);
+	t("Boolean attribute equals", "#select2 option[selected='selected']", [
+		"option2d"
+	]);
 
 	t("Attribute Equals", "#qunit-fixture a[rel='bookmark']", ["simon1"]);
 	t("Attribute Equals", "#qunit-fixture a[rel='bookmark']", ["simon1"]);
 	t("Attribute Equals", "#qunit-fixture a[rel=bookmark]", ["simon1"]);
-	t("Attribute Equals", "#qunit-fixture a[href='http://www.google.com/']", ["google"]);
+	t("Attribute Equals", "#qunit-fixture a[href='http://www.google.com/']", [
+		"google"
+	]);
 	t("Attribute Equals", "#qunit-fixture a[ rel = 'bookmark' ]", ["simon1"]);
-	t("Attribute Equals Number", "#qunit-fixture option[value=1]", ["option1b","option2b","option3b","option4b","option5c"]);
-	t("Attribute Equals Number", "#qunit-fixture li[tabIndex=-1]", ["foodWithNegativeTabIndex"]);
+	t("Attribute Equals Number", "#qunit-fixture option[value=1]", [
+		"option1b",
+		"option2b",
+		"option3b",
+		"option4b",
+		"option5c"
+	]);
+	t("Attribute Equals Number", "#qunit-fixture li[tabIndex=-1]", [
+		"foodWithNegativeTabIndex"
+	]);
 
 	document.getElementById("anchor2").href = "#2";
 	t("href Attribute", "p a[href^=#]", ["anchor2"]);
@@ -522,46 +915,108 @@ test("attributes", function(){
 	t("Attribute containing []", "input[name$='foo[bar]']", ["hidden2"]);
 	t("Attribute containing []", "input[name*='foo[bar]']", ["hidden2"]);
 
-	deepEqual(Sizzle("input[data-comma='0,1']"), [ document.getElementById("el12087") ], "Without context, single-quoted attribute containing ','");
-	deepEqual(Sizzle("input[data-comma=\"0,1\"]"), [ document.getElementById("el12087") ], "Without context, double-quoted attribute containing ','");
-	deepEqual(Sizzle("input[data-comma='0,1']", document.getElementById("t12087")), [ document.getElementById("el12087") ], "With context, single-quoted attribute containing ','");
-	deepEqual(Sizzle("input[data-comma=\"0,1\"]", document.getElementById("t12087")), [ document.getElementById("el12087") ], "With context, double-quoted attribute containing ','");
+	deepEqual(
+		Sizzle("input[data-comma='0,1']"),
+		[document.getElementById("el12087")],
+		"Without context, single-quoted attribute containing ','"
+	);
+	deepEqual(
+		Sizzle("input[data-comma=\"0,1\"]"),
+		[document.getElementById("el12087")],
+		"Without context, double-quoted attribute containing ','"
+	);
+	deepEqual(
+		Sizzle("input[data-comma='0,1']", document.getElementById("t12087")),
+		[document.getElementById("el12087")],
+		"With context, single-quoted attribute containing ','"
+	);
+	deepEqual(
+		Sizzle("input[data-comma=\"0,1\"]", document.getElementById("t12087")),
+		[document.getElementById("el12087")],
+		"With context, double-quoted attribute containing ','"
+	);
 
-	t("Multiple Attribute Equals", "#form input[type='radio'], #form input[type='hidden']", ["radio1", "radio2", "hidden1"]);
-	t("Multiple Attribute Equals", "#form input[type='radio'], #form input[type=\"hidden\"]", ["radio1", "radio2", "hidden1"]);
-	t("Multiple Attribute Equals", "#form input[type='radio'], #form input[type=hidden]", ["radio1", "radio2", "hidden1"]);
+	t(
+		"Multiple Attribute Equals",
+		"#form input[type='radio'], #form input[type='hidden']",
+		["radio1", "radio2", "hidden1"]
+	);
+	t(
+		"Multiple Attribute Equals",
+		"#form input[type='radio'], #form input[type=\"hidden\"]",
+		["radio1", "radio2", "hidden1"]
+	);
+	t(
+		"Multiple Attribute Equals",
+		"#form input[type='radio'], #form input[type=hidden]",
+		["radio1", "radio2", "hidden1"]
+	);
 
 	t("Attribute selector using UTF8", "span[lang=中文]", ["台北"]);
 
-	t("Attribute Begins With", "a[href ^= 'http://www']", ["google","yahoo"]);
+	t("Attribute Begins With", "a[href ^= 'http://www']", ["google", "yahoo"]);
 	t("Attribute Ends With", "a[href $= 'org/']", ["mark"]);
-	t("Attribute Contains", "a[href *= 'google']", ["google","groups"]);
-	t("Attribute Is Not Equal", "#ap a[hreflang!='en']", ["google","groups","anchor1"]);
+	t("Attribute Contains", "a[href *= 'google']", ["google", "groups"]);
+	t("Attribute Is Not Equal", "#ap a[hreflang!='en']", [
+		"google",
+		"groups",
+		"anchor1"
+	]);
 
 	opt = document.getElementById("option1a");
 	opt.attribs.test = "";
 
-	ok(Sizzle.matchesSelector(opt, "[id*=option1][type!=checkbox]"), "Attribute Is Not Equal Matches");
-	ok(Sizzle.matchesSelector(opt, "[id*=option1]"), "Attribute With No Quotes Contains Matches");
-	ok(Sizzle.matchesSelector(opt, "[test=]"), "Attribute With No Quotes No Content Matches");
-	ok(!Sizzle.matchesSelector(opt, "[test^='']"), "Attribute with empty string value does not match startsWith selector (^=)");
-	ok(Sizzle.matchesSelector(opt, "[id=option1a]"), "Attribute With No Quotes Equals Matches");
-	ok(Sizzle.matchesSelector(document.getElementById("simon1"), "a[href*=#]"), "Attribute With No Quotes Href Contains Matches");
+	ok(
+		Sizzle.matchesSelector(opt, "[id*=option1][type!=checkbox]"),
+		"Attribute Is Not Equal Matches"
+	);
+	ok(
+		Sizzle.matchesSelector(opt, "[id*=option1]"),
+		"Attribute With No Quotes Contains Matches"
+	);
+	ok(
+		Sizzle.matchesSelector(opt, "[test=]"),
+		"Attribute With No Quotes No Content Matches"
+	);
+	ok(
+		!Sizzle.matchesSelector(opt, "[test^='']"),
+		"Attribute with empty string value does not match startsWith selector (^=)"
+	);
+	ok(
+		Sizzle.matchesSelector(opt, "[id=option1a]"),
+		"Attribute With No Quotes Equals Matches"
+	);
+	ok(
+		Sizzle.matchesSelector(document.getElementById("simon1"), "a[href*=#]"),
+		"Attribute With No Quotes Href Contains Matches"
+	);
 
 	t("Empty values", "#select1 option[value='']", ["option1a"]);
-	t("Empty values", "#select1 option[value!='']", ["option1b","option1c","option1d"]);
+	t("Empty values", "#select1 option[value!='']", [
+		"option1b",
+		"option1c",
+		"option1d"
+	]);
 
 	t("Select options via :selected", "#select1 option:selected", ["option1a"]);
 	t("Select options via :selected", "#select2 option:selected", ["option2d"]);
-	t("Select options via :selected", "#select3 option:selected", ["option3b", "option3c"]);
-	t("Select options via :selected", "select[name='select2'] option:selected", ["option2d"]);
+	t("Select options via :selected", "#select3 option:selected", [
+		"option3b",
+		"option3c"
+	]);
+	t("Select options via :selected", "select[name='select2'] option:selected", [
+		"option2d"
+	]);
 
 	t("Grouped Form Elements", "input[name='foo[bar]']", ["hidden2"]);
 
 	input = document.getElementById("text1");
 	input.attribs.title = "Don't click me";
 
-	ok(Sizzle.matchesSelector(input, "input[title=\"Don't click me\"]"), "Quote within attribute value does not mess up tokenizer");
+	ok(
+		Sizzle.matchesSelector(input, "input[title=\"Don't click me\"]"),
+		"Quote within attribute value does not mess up tokenizer"
+	);
 
 	// Uncomment if the boolHook is removed
 	// var check2 = document.getElementById("check2");
@@ -570,33 +1025,51 @@ test("attributes", function(){
 
 	// jQuery #12303
 	input.attribs["data-pos"] = ":first";
-	ok(Sizzle.matchesSelector(input, "input[data-pos=\\:first]"), "POS within attribute value is treated as an attribute value");
-	ok(Sizzle.matchesSelector(input, "input[data-pos=':first']"), "POS within attribute value is treated as an attribute value");
-	ok(Sizzle.matchesSelector(input, ":input[data-pos=':first']"), "POS within attribute value after pseudo is treated as an attribute value");
+	ok(
+		Sizzle.matchesSelector(input, "input[data-pos=\\:first]"),
+		"POS within attribute value is treated as an attribute value"
+	);
+	ok(
+		Sizzle.matchesSelector(input, "input[data-pos=':first']"),
+		"POS within attribute value is treated as an attribute value"
+	);
+	ok(
+		Sizzle.matchesSelector(input, ":input[data-pos=':first']"),
+		"POS within attribute value after pseudo is treated as an attribute value"
+	);
 	delete input.attribs["data-pos"];
 
 	// Make sure attribute value quoting works correctly. See jQuery #6093; #6428; #13894
 	// Use seeded results to bypass querySelectorAll optimizations
 	attrbad = jQuery(
 		"<input type='hidden' id='attrbad_space' name='foo bar'/>" +
-		"<input type='hidden' id='attrbad_dot' value='2' name='foo.baz'/>" +
-		"<input type='hidden' id='attrbad_brackets' value='2' name='foo[baz]'/>" +
-		"<input type='hidden' id='attrbad_injection' data-attr='foo_baz&#39;]'/>" +
-		"<input type='hidden' id='attrbad_quote' data-attr='&#39;'/>" +
-		"<input type='hidden' id='attrbad_backslash' data-attr='&#92;'/>" +
-		"<input type='hidden' id='attrbad_backslash_quote' data-attr='&#92;&#39;'/>" +
-		"<input type='hidden' id='attrbad_backslash_backslash' data-attr='&#92;&#92;'/>" +
-		"<input type='hidden' id='attrbad_unicode' data-attr='&#x4e00;'/>"
+			"<input type='hidden' id='attrbad_dot' value='2' name='foo.baz'/>" +
+			"<input type='hidden' id='attrbad_brackets' value='2' name='foo[baz]'/>" +
+			"<input type='hidden' id='attrbad_injection' data-attr='foo_baz&#39;]'/>" +
+			"<input type='hidden' id='attrbad_quote' data-attr='&#39;'/>" +
+			"<input type='hidden' id='attrbad_backslash' data-attr='&#92;'/>" +
+			"<input type='hidden' id='attrbad_backslash_quote' data-attr='&#92;&#39;'/>" +
+			"<input type='hidden' id='attrbad_backslash_backslash' data-attr='&#92;&#92;'/>" +
+			"<input type='hidden' id='attrbad_unicode' data-attr='&#x4e00;'/>"
 	).appendTo("#qunit-fixture");
 
 	t("Underscores don't need escaping", "input[id=types_all]", ["types_all"]);
 
-	deepEqual(Sizzle("input[name=foo\\ bar]", null, null, attrbad), q("attrbad_space"),
-		"Escaped space");
-	deepEqual(Sizzle("input[name=foo\\.baz]", null, null, attrbad), q("attrbad_dot"),
-		"Escaped dot");
-	deepEqual(Sizzle("input[name=foo\\[baz\\]]", null, null, attrbad), q("attrbad_brackets"),
-		"Escaped brackets");
+	deepEqual(
+		Sizzle("input[name=foo\\ bar]", null, null, attrbad),
+		q("attrbad_space"),
+		"Escaped space"
+	);
+	deepEqual(
+		Sizzle("input[name=foo\\.baz]", null, null, attrbad),
+		q("attrbad_dot"),
+		"Escaped dot"
+	);
+	deepEqual(
+		Sizzle("input[name=foo\\[baz\\]]", null, null, attrbad),
+		q("attrbad_brackets"),
+		"Escaped brackets"
+	);
 	//  deepEqual( Sizzle( "input[data-attr='foo_baz\\']']", null, null, attrbad ), q("attrbad_injection"),
 	//	"Escaped quote + right bracket" );
 
@@ -617,14 +1090,23 @@ test("attributes", function(){
 	//	"Quoted backslash backslash (numeric escape with trailing tab)" );
 	//  deepEqual( Sizzle( "input[data-attr='\\04e00']", null, null, attrbad ), q("attrbad_unicode"),
 	//	"Long numeric escape (BMP)" );*/
-	document.getElementById("attrbad_unicode").attribs["data-attr"] = "\uD834\uDF06A";
+	document.getElementById("attrbad_unicode").attribs["data-attr"] =
+		"\uD834\uDF06A";
 	// It was too much code to fix Safari 5.x Supplemental Plane crashes (see ba5f09fa404379a87370ec905ffa47f8ac40aaa3)
-	deepEqual(Sizzle("input[data-attr='\\01D306A']", null, null, attrbad), q("attrbad_unicode"),
-		"Long numeric escape (non-BMP)");
+	deepEqual(
+		Sizzle("input[data-attr='\\01D306A']", null, null, attrbad),
+		q("attrbad_unicode"),
+		"Long numeric escape (non-BMP)"
+	);
 
 	attrbad.remove();
 
-	t("input[type=text]", "#form input[type=text]", ["text1", "text2", "hidden2", "name"]);
+	t("input[type=text]", "#form input[type=text]", [
+		"text1",
+		"text2",
+		"hidden2",
+		"name"
+	]);
 	t("input[type=search]", "#form input[type=search]", ["search"]);
 	t("script[src] (jQuery #13777)", "#moretests script[src]", ["script-src"]);
 
@@ -632,7 +1114,11 @@ test("attributes", function(){
 	div = document.createElement("div");
 	div.children = helper.getDOM("<div id='foo' xml:test='something'></div>");
 
-	deepEqual(Sizzle("[xml\\:test]", div), [ div.children[0] ], "Finding by attribute with escaped characters.");
+	deepEqual(
+		Sizzle("[xml\\:test]", div),
+		[div.children[0]],
+		"Finding by attribute with escaped characters."
+	);
 
 	div = document.getElementById("foo");
 	t("Object.prototype property \"constructor\" (negative)", "[constructor]", []);
@@ -642,48 +1128,96 @@ test("attributes", function(){
 	t("Object.prototype property \"constructor\"", "[constructor='foo']", ["foo"]);
 	t("Gecko Object.prototype property \"watch\"", "[watch='bar']", ["foo"]);
 
-	t("Value attribute is retrieved correctly", "input[value=Test]", ["text1", "text2"]);
+	t("Value attribute is retrieved correctly", "input[value=Test]", [
+		"text1",
+		"text2"
+	]);
 });
 
 test("pseudo - (parent|empty)", function(){
 	expect(3);
 	t("Empty", "ul:empty", ["firstUL"]);
 	t("Empty with comment node", "ol:empty", ["empty"]);
-	t("Is A Parent", "#qunit-fixture p:parent", ["firstp","ap","sndp","en","sap","first"]);
+	t("Is A Parent", "#qunit-fixture p:parent", [
+		"firstp",
+		"ap",
+		"sndp",
+		"en",
+		"sap",
+		"first"
+	]);
 });
 
 test("pseudo - (first|last|only)-(child|of-type)", function(){
 	expect(12);
 
-	t("First Child", "p:first-child", ["firstp","sndp"]);
-	t("First Child (leading id)", "#qunit-fixture p:first-child", ["firstp","sndp"]);
-	t("First Child (leading class)", ".nothiddendiv div:first-child", ["nothiddendivchild"]);
-	t("First Child (case-insensitive)", "#qunit-fixture p:FIRST-CHILD", ["firstp","sndp"]);
+	t("First Child", "p:first-child", ["firstp", "sndp"]);
+	t("First Child (leading id)", "#qunit-fixture p:first-child", [
+		"firstp",
+		"sndp"
+	]);
+	t("First Child (leading class)", ".nothiddendiv div:first-child", [
+		"nothiddendivchild"
+	]);
+	t("First Child (case-insensitive)", "#qunit-fixture p:FIRST-CHILD", [
+		"firstp",
+		"sndp"
+	]);
 
 	t("Last Child", "p:last-child", ["sap"]);
-	t("Last Child (leading id)", "#qunit-fixture a:last-child", ["simon1","anchor1","mark","yahoo","anchor2","simon","liveLink1","liveLink2"]);
+	t("Last Child (leading id)", "#qunit-fixture a:last-child", [
+		"simon1",
+		"anchor1",
+		"mark",
+		"yahoo",
+		"anchor2",
+		"simon",
+		"liveLink1",
+		"liveLink2"
+	]);
 
-	t("Only Child", "#qunit-fixture a:only-child", ["simon1","anchor1","yahoo","anchor2","liveLink1","liveLink2"]);
+	t("Only Child", "#qunit-fixture a:only-child", [
+		"simon1",
+		"anchor1",
+		"yahoo",
+		"anchor2",
+		"liveLink1",
+		"liveLink2"
+	]);
 
 	t("First-of-type", "#qunit-fixture > p:first-of-type", ["firstp"]);
 	t("Last-of-type", "#qunit-fixture > p:last-of-type", ["first"]);
-	t("Only-of-type", "#qunit-fixture > :only-of-type", ["name+value", "firstUL", "empty", "floatTest", "iframe", "table"]);
+	t("Only-of-type", "#qunit-fixture > :only-of-type", [
+		"name+value",
+		"firstUL",
+		"empty",
+		"floatTest",
+		"iframe",
+		"table"
+	]);
 
 	// Verify that the child position isn't being cached improperly
 	var secondChildren = jQuery(Sizzle("p:nth-child(2)")).before("<div></div>");
 
 	t("No longer second child", "p:nth-child(2)", []);
 	secondChildren.prev().remove();
-	t("Restored second child", "p:nth-child(2)", ["ap","en"]);
+	t("Restored second child", "p:nth-child(2)", ["ap", "en"]);
 });
 
 test("pseudo - nth-child", function(){
 	expect(30);
 
-	t("Nth-child", "p:nth-child(1)", ["firstp","sndp"]);
-	t("Nth-child (with whitespace)", "p:nth-child( 1 )", ["firstp","sndp"]);
-	t("Nth-child (case-insensitive)", "#select1 option:NTH-child(3)", ["option1c"]);
-	t("Not nth-child", "#qunit-fixture p:not(:nth-child(1))", ["ap","en","sap","first"]);
+	t("Nth-child", "p:nth-child(1)", ["firstp", "sndp"]);
+	t("Nth-child (with whitespace)", "p:nth-child( 1 )", ["firstp", "sndp"]);
+	t("Nth-child (case-insensitive)", "#select1 option:NTH-child(3)", [
+		"option1c"
+	]);
+	t("Not nth-child", "#qunit-fixture p:not(:nth-child(1))", [
+		"ap",
+		"en",
+		"sap",
+		"first"
+	]);
 
 	t("Nth-child(2)", "#qunit-fixture form#form > *:nth-child(2)", ["text1"]);
 	t("Nth-child(2)", "#qunit-fixture form#form > :nth-child(2)", ["text1"]);
@@ -691,26 +1225,74 @@ test("pseudo - nth-child", function(){
 	t("Nth-child(-1)", "#select1 option:nth-child(-1)", []);
 	t("Nth-child(3)", "#select1 option:nth-child(3)", ["option1c"]);
 	//  t( "Nth-child(0n+3)", "#select1 option:nth-child(0n+3)", ["option1c"] );
-	t("Nth-child(1n+0)", "#select1 option:nth-child(1n+0)", ["option1a", "option1b", "option1c", "option1d"]);
-	t("Nth-child(1n)", "#select1 option:nth-child(1n)", ["option1a", "option1b", "option1c", "option1d"]);
-	t("Nth-child(n)", "#select1 option:nth-child(n)", ["option1a", "option1b", "option1c", "option1d"]);
-	t("Nth-child(even)", "#select1 option:nth-child(even)", ["option1b", "option1d"]);
-	t("Nth-child(odd)", "#select1 option:nth-child(odd)", ["option1a", "option1c"]);
+	t("Nth-child(1n+0)", "#select1 option:nth-child(1n+0)", [
+		"option1a",
+		"option1b",
+		"option1c",
+		"option1d"
+	]);
+	t("Nth-child(1n)", "#select1 option:nth-child(1n)", [
+		"option1a",
+		"option1b",
+		"option1c",
+		"option1d"
+	]);
+	t("Nth-child(n)", "#select1 option:nth-child(n)", [
+		"option1a",
+		"option1b",
+		"option1c",
+		"option1d"
+	]);
+	t("Nth-child(even)", "#select1 option:nth-child(even)", [
+		"option1b",
+		"option1d"
+	]);
+	t("Nth-child(odd)", "#select1 option:nth-child(odd)", [
+		"option1a",
+		"option1c"
+	]);
 	t("Nth-child(2n)", "#select1 option:nth-child(2n)", ["option1b", "option1d"]);
-	t("Nth-child(2n+1)", "#select1 option:nth-child(2n+1)", ["option1a", "option1c"]);
-	t("Nth-child(2n + 1)", "#select1 option:nth-child(2n + 1)", ["option1a", "option1c"]);
-	t("Nth-child(+2n + 1)", "#select1 option:nth-child(+2n + 1)", ["option1a", "option1c"]);
+	t("Nth-child(2n+1)", "#select1 option:nth-child(2n+1)", [
+		"option1a",
+		"option1c"
+	]);
+	t("Nth-child(2n + 1)", "#select1 option:nth-child(2n + 1)", [
+		"option1a",
+		"option1c"
+	]);
+	t("Nth-child(+2n + 1)", "#select1 option:nth-child(+2n + 1)", [
+		"option1a",
+		"option1c"
+	]);
 	t("Nth-child(3n)", "#select1 option:nth-child(3n)", ["option1c"]);
-	t("Nth-child(3n+1)", "#select1 option:nth-child(3n+1)", ["option1a", "option1d"]);
+	t("Nth-child(3n+1)", "#select1 option:nth-child(3n+1)", [
+		"option1a",
+		"option1d"
+	]);
 	t("Nth-child(3n+2)", "#select1 option:nth-child(3n+2)", ["option1b"]);
 	t("Nth-child(3n+3)", "#select1 option:nth-child(3n+3)", ["option1c"]);
 	t("Nth-child(3n-1)", "#select1 option:nth-child(3n-1)", ["option1b"]);
-	t("Nth-child(3n-2)", "#select1 option:nth-child(3n-2)", ["option1a", "option1d"]);
+	t("Nth-child(3n-2)", "#select1 option:nth-child(3n-2)", [
+		"option1a",
+		"option1d"
+	]);
 	t("Nth-child(3n-3)", "#select1 option:nth-child(3n-3)", ["option1c"]);
 	t("Nth-child(3n+0)", "#select1 option:nth-child(3n+0)", ["option1c"]);
-	t("Nth-child(-1n+3)", "#select1 option:nth-child(-1n+3)", ["option1a", "option1b", "option1c"]);
-	t("Nth-child(-n+3)", "#select1 option:nth-child(-n+3)", ["option1a", "option1b", "option1c"]);
-	t("Nth-child(-1n + 3)", "#select1 option:nth-child(-1n + 3)", ["option1a", "option1b", "option1c"]);
+	t("Nth-child(-1n+3)", "#select1 option:nth-child(-1n+3)", [
+		"option1a",
+		"option1b",
+		"option1c"
+	]);
+	t("Nth-child(-n+3)", "#select1 option:nth-child(-n+3)", [
+		"option1a",
+		"option1b",
+		"option1c"
+	]);
+	t("Nth-child(-1n + 3)", "#select1 option:nth-child(-1n + 3)", [
+		"option1a",
+		"option1b",
+		"option1c"
+	]);
 
 	//  deepEqual( Sizzle( ":nth-child(n)", null, null, [ document.createElement("a") ].concat( q("ap") ) ), q("ap"), "Seeded nth-child" );
 });
@@ -719,35 +1301,106 @@ test("pseudo - nth-last-child", function(){
 	expect(30);
 
 	t("Nth-last-child", "form:nth-last-child(5)", ["testForm"]);
-	t("Nth-last-child (with whitespace)", "form:nth-last-child( 5 )", ["testForm"]);
-	t("Nth-last-child (case-insensitive)", "#select1 option:NTH-last-child(3)", ["option1b"]);
-	t("Not nth-last-child", "#qunit-fixture p:not(:nth-last-child(1))", ["firstp", "ap", "sndp", "en", "first"]);
+	t("Nth-last-child (with whitespace)", "form:nth-last-child( 5 )", [
+		"testForm"
+	]);
+	t("Nth-last-child (case-insensitive)", "#select1 option:NTH-last-child(3)", [
+		"option1b"
+	]);
+	t("Not nth-last-child", "#qunit-fixture p:not(:nth-last-child(1))", [
+		"firstp",
+		"ap",
+		"sndp",
+		"en",
+		"first"
+	]);
 
 	t("Nth-last-child(-1)", "#select1 option:nth-last-child(-1)", []);
 	t("Nth-last-child(3)", "#select1 :nth-last-child(3)", ["option1b"]);
 	t("Nth-last-child(3)", "#select1 *:nth-last-child(3)", ["option1b"]);
 	t("Nth-last-child(3)", "#select1 option:nth-last-child(3)", ["option1b"]);
 	//  t( "Nth-last-child(0n+3)", "#select1 option:nth-last-child(0n+3)", ["option1b"] );
-	t("Nth-last-child(1n+0)", "#select1 option:nth-last-child(1n+0)", ["option1a", "option1b", "option1c", "option1d"]);
-	t("Nth-last-child(1n)", "#select1 option:nth-last-child(1n)", ["option1a", "option1b", "option1c", "option1d"]);
-	t("Nth-last-child(n)", "#select1 option:nth-last-child(n)", ["option1a", "option1b", "option1c", "option1d"]);
-	t("Nth-last-child(even)", "#select1 option:nth-last-child(even)", ["option1a", "option1c"]);
-	t("Nth-last-child(odd)", "#select1 option:nth-last-child(odd)", ["option1b", "option1d"]);
-	t("Nth-last-child(2n)", "#select1 option:nth-last-child(2n)", ["option1a", "option1c"]);
-	t("Nth-last-child(2n+1)", "#select1 option:nth-last-child(2n+1)", ["option1b", "option1d"]);
-	t("Nth-last-child(2n + 1)", "#select1 option:nth-last-child(2n + 1)", ["option1b", "option1d"]);
-	t("Nth-last-child(+2n + 1)", "#select1 option:nth-last-child(+2n + 1)", ["option1b", "option1d"]);
+	t("Nth-last-child(1n+0)", "#select1 option:nth-last-child(1n+0)", [
+		"option1a",
+		"option1b",
+		"option1c",
+		"option1d"
+	]);
+	t("Nth-last-child(1n)", "#select1 option:nth-last-child(1n)", [
+		"option1a",
+		"option1b",
+		"option1c",
+		"option1d"
+	]);
+	t("Nth-last-child(n)", "#select1 option:nth-last-child(n)", [
+		"option1a",
+		"option1b",
+		"option1c",
+		"option1d"
+	]);
+	t("Nth-last-child(even)", "#select1 option:nth-last-child(even)", [
+		"option1a",
+		"option1c"
+	]);
+	t("Nth-last-child(odd)", "#select1 option:nth-last-child(odd)", [
+		"option1b",
+		"option1d"
+	]);
+	t("Nth-last-child(2n)", "#select1 option:nth-last-child(2n)", [
+		"option1a",
+		"option1c"
+	]);
+	t("Nth-last-child(2n+1)", "#select1 option:nth-last-child(2n+1)", [
+		"option1b",
+		"option1d"
+	]);
+	t("Nth-last-child(2n + 1)", "#select1 option:nth-last-child(2n + 1)", [
+		"option1b",
+		"option1d"
+	]);
+	t("Nth-last-child(+2n + 1)", "#select1 option:nth-last-child(+2n + 1)", [
+		"option1b",
+		"option1d"
+	]);
 	t("Nth-last-child(3n)", "#select1 option:nth-last-child(3n)", ["option1b"]);
-	t("Nth-last-child(3n+1)", "#select1 option:nth-last-child(3n+1)", ["option1a", "option1d"]);
-	t("Nth-last-child(3n+2)", "#select1 option:nth-last-child(3n+2)", ["option1c"]);
-	t("Nth-last-child(3n+3)", "#select1 option:nth-last-child(3n+3)", ["option1b"]);
-	t("Nth-last-child(3n-1)", "#select1 option:nth-last-child(3n-1)", ["option1c"]);
-	t("Nth-last-child(3n-2)", "#select1 option:nth-last-child(3n-2)", ["option1a", "option1d"]);
-	t("Nth-last-child(3n-3)", "#select1 option:nth-last-child(3n-3)", ["option1b"]);
-	t("Nth-last-child(3n+0)", "#select1 option:nth-last-child(3n+0)", ["option1b"]);
-	t("Nth-last-child(-1n+3)", "#select1 option:nth-last-child(-1n+3)", ["option1b", "option1c", "option1d"]);
-	t("Nth-last-child(-n+3)", "#select1 option:nth-last-child(-n+3)", ["option1b", "option1c", "option1d"]);
-	t("Nth-last-child(-1n + 3)", "#select1 option:nth-last-child(-1n + 3)", ["option1b", "option1c", "option1d"]);
+	t("Nth-last-child(3n+1)", "#select1 option:nth-last-child(3n+1)", [
+		"option1a",
+		"option1d"
+	]);
+	t("Nth-last-child(3n+2)", "#select1 option:nth-last-child(3n+2)", [
+		"option1c"
+	]);
+	t("Nth-last-child(3n+3)", "#select1 option:nth-last-child(3n+3)", [
+		"option1b"
+	]);
+	t("Nth-last-child(3n-1)", "#select1 option:nth-last-child(3n-1)", [
+		"option1c"
+	]);
+	t("Nth-last-child(3n-2)", "#select1 option:nth-last-child(3n-2)", [
+		"option1a",
+		"option1d"
+	]);
+	t("Nth-last-child(3n-3)", "#select1 option:nth-last-child(3n-3)", [
+		"option1b"
+	]);
+	t("Nth-last-child(3n+0)", "#select1 option:nth-last-child(3n+0)", [
+		"option1b"
+	]);
+	t("Nth-last-child(-1n+3)", "#select1 option:nth-last-child(-1n+3)", [
+		"option1b",
+		"option1c",
+		"option1d"
+	]);
+	t("Nth-last-child(-n+3)", "#select1 option:nth-last-child(-n+3)", [
+		"option1b",
+		"option1c",
+		"option1d"
+	]);
+	t("Nth-last-child(-1n + 3)", "#select1 option:nth-last-child(-1n + 3)", [
+		"option1b",
+		"option1c",
+		"option1d"
+	]);
 
 	//  deepEqual( Sizzle( ":nth-last-child(n)", null, null, [ document.createElement("a") ].concat( q("ap") ) ), q("ap"), "Seeded nth-last-child" );
 });
@@ -756,34 +1409,101 @@ test("pseudo - nth-of-type", function(){
 	expect(9);
 	t("Nth-of-type(-1)", ":nth-of-type(-1)", []);
 	t("Nth-of-type(3)", "#ap :nth-of-type(3)", ["mark"]);
-	t("Nth-of-type(n)", "#ap :nth-of-type(n)", ["google", "groups", "code1", "anchor1", "mark"]);
+	t("Nth-of-type(n)", "#ap :nth-of-type(n)", [
+		"google",
+		"groups",
+		"code1",
+		"anchor1",
+		"mark"
+	]);
 	t("Nth-of-type(0n+3)", "#ap :nth-of-type(0n+3)", ["mark"]);
 	t("Nth-of-type(2n)", "#ap :nth-of-type(2n)", ["groups"]);
 	t("Nth-of-type(even)", "#ap :nth-of-type(even)", ["groups"]);
-	t("Nth-of-type(2n+1)", "#ap :nth-of-type(2n+1)", ["google", "code1", "anchor1", "mark"]);
-	t("Nth-of-type(odd)", "#ap :nth-of-type(odd)", ["google", "code1", "anchor1", "mark"]);
-	t("Nth-of-type(-n+2)", "#qunit-fixture > :nth-of-type(-n+2)", ["firstp", "ap", "foo", "nothiddendiv", "name+value", "firstUL", "empty", "form", "floatTest", "iframe", "lengthtest", "table"]);
+	t("Nth-of-type(2n+1)", "#ap :nth-of-type(2n+1)", [
+		"google",
+		"code1",
+		"anchor1",
+		"mark"
+	]);
+	t("Nth-of-type(odd)", "#ap :nth-of-type(odd)", [
+		"google",
+		"code1",
+		"anchor1",
+		"mark"
+	]);
+	t("Nth-of-type(-n+2)", "#qunit-fixture > :nth-of-type(-n+2)", [
+		"firstp",
+		"ap",
+		"foo",
+		"nothiddendiv",
+		"name+value",
+		"firstUL",
+		"empty",
+		"form",
+		"floatTest",
+		"iframe",
+		"lengthtest",
+		"table"
+	]);
 });
 
 test("pseudo - nth-last-of-type", function(){
 	expect(9);
 	t("Nth-last-of-type(-1)", ":nth-last-of-type(-1)", []);
 	t("Nth-last-of-type(3)", "#ap :nth-last-of-type(3)", ["google"]);
-	t("Nth-last-of-type(n)", "#ap :nth-last-of-type(n)", ["google", "groups", "code1", "anchor1", "mark"]);
+	t("Nth-last-of-type(n)", "#ap :nth-last-of-type(n)", [
+		"google",
+		"groups",
+		"code1",
+		"anchor1",
+		"mark"
+	]);
 	t("Nth-last-of-type(0n+3)", "#ap :nth-last-of-type(0n+3)", ["google"]);
 	t("Nth-last-of-type(2n)", "#ap :nth-last-of-type(2n)", ["groups"]);
 	t("Nth-last-of-type(even)", "#ap :nth-last-of-type(even)", ["groups"]);
-	t("Nth-last-of-type(2n+1)", "#ap :nth-last-of-type(2n+1)", ["google", "code1", "anchor1", "mark"]);
-	t("Nth-last-of-type(odd)", "#ap :nth-last-of-type(odd)", ["google", "code1", "anchor1", "mark"]);
-	t("Nth-last-of-type(-n+2)", "#qunit-fixture > :nth-last-of-type(-n+2)", ["ap", "name+value", "first", "firstUL", "empty", "floatTest", "iframe", "table", "name-tests", "testForm", "liveHandlerOrder", "siblingTest"]);
+	t("Nth-last-of-type(2n+1)", "#ap :nth-last-of-type(2n+1)", [
+		"google",
+		"code1",
+		"anchor1",
+		"mark"
+	]);
+	t("Nth-last-of-type(odd)", "#ap :nth-last-of-type(odd)", [
+		"google",
+		"code1",
+		"anchor1",
+		"mark"
+	]);
+	t("Nth-last-of-type(-n+2)", "#qunit-fixture > :nth-last-of-type(-n+2)", [
+		"ap",
+		"name+value",
+		"first",
+		"firstUL",
+		"empty",
+		"floatTest",
+		"iframe",
+		"table",
+		"name-tests",
+		"testForm",
+		"liveHandlerOrder",
+		"siblingTest"
+	]);
 });
 
 test("pseudo - has", function(){
 	expect(3);
 
-	t("Basic test", "p:has(a)", ["firstp","ap","en","sap"]);
-	t("Basic test (irrelevant whitespace)", "p:has( a )", ["firstp","ap","en","sap"]);
-	t("Nested with overlapping candidates", "#qunit-fixture div:has(div:has(div:not([id])))", [ "moretests", "t2037" ]);
+	t("Basic test", "p:has(a)", ["firstp", "ap", "en", "sap"]);
+	t("Basic test (irrelevant whitespace)", "p:has( a )", [
+		"firstp",
+		"ap",
+		"en",
+		"sap"
+	]);
+	t(
+		"Nested with overlapping candidates",
+		"#qunit-fixture div:has(div:has(div:not([id])))",
+		["moretests", "t2037"]
+	);
 });
 
 test("pseudo - misc", function(){
@@ -792,16 +1512,27 @@ test("pseudo - misc", function(){
 	var select, tmp, input;
 
 	t("Headers", ":header", ["qunit-header", "qunit-banner", "qunit-userAgent"]);
-	t("Headers(case-insensitive)", ":Header", ["qunit-header", "qunit-banner", "qunit-userAgent"]);
-	t("Multiple matches with the same context (cache check)", "#form select:has(option:first-child:contains('o'))", ["select1", "select2", "select3", "select4"]);
+	t("Headers(case-insensitive)", ":Header", [
+		"qunit-header",
+		"qunit-banner",
+		"qunit-userAgent"
+	]);
+	t(
+		"Multiple matches with the same context (cache check)",
+		"#form select:has(option:first-child:contains('o'))",
+		["select1", "select2", "select3", "select4"]
+	);
 
-	ok(Sizzle("#qunit-fixture :not(:has(:has(*)))").length, "All not grandparents");
+	ok(
+		Sizzle("#qunit-fixture :not(:has(:has(*)))").length,
+		"All not grandparents"
+	);
 
 	select = document.getElementById("select1");
 	ok(Sizzle.matchesSelector(select, ":has(option)"), "Has Option Matches");
 
 	ok(Sizzle("a:contains('')").length, "Empty string contains");
-	t("Text Contains", "a:contains(Google)", ["google","groups"]);
+	t("Text Contains", "a:contains(Google)", ["google", "groups"]);
 	t("Text Contains", "a:contains(Google Groups)", ["groups"]);
 
 	t("Text Contains", "a:contains('Google Groups (Link)')", ["groups"]);
@@ -809,18 +1540,22 @@ test("pseudo - misc", function(){
 	t("Text Contains", "a:contains(Google Groups (Link))", ["groups"]);
 	t("Text Contains", "a:contains((Link))", ["groups"]);
 
-
 	tmp = document.createElement("div");
 	tmp.attribs.id = "tmp_input";
 	document.body.children.push(tmp);
 
-	[ "button", "submit", "reset" ].forEach(function(type){
+	["button", "submit", "reset"].forEach(function(type){
 		var els = jQuery(
-			"<input id='input_%' type='%'/><button id='button_%' type='%'>test</button>"
-			.replace(/%/g, type)
+			"<input id='input_%' type='%'/><button id='button_%' type='%'>test</button>".replace(
+				/%/g,
+				type
+			)
 		).appendTo(tmp);
 
-		t("Input Buttons :" + type, "#tmp_input :" + type, [ "input_" + type, "button_" + type ]);
+		t("Input Buttons :" + type, "#tmp_input :" + type, [
+			"input_" + type,
+			"button_" + type
+		]);
 
 		ok(Sizzle.matchesSelector(els[0], ":" + type), "Input Matches :" + type);
 		ok(Sizzle.matchesSelector(els[1], ":" + type), "Button Matches :" + type);
@@ -837,12 +1572,16 @@ test("pseudo - misc", function(){
 	document.body.children.push(tmp);
 	tmp.tabIndex = 0;
 	//tmp.focus();
-	if(document.activeElement !== tmp || (document.hasFocus && !document.hasFocus()) ||
-		(document.querySelectorAll && !document.querySelectorAll("div:focus").length)){
+	if(
+		document.activeElement !== tmp ||
+		(document.hasFocus && !document.hasFocus()) ||
+		(document.querySelectorAll &&
+			!document.querySelectorAll("div:focus").length)
+	){
 		ok(true, "The div was not focused. Skip checking the :focus match.");
 		ok(true, "The div was not focused. Skip checking the :focus match.");
 	} else {
-		t("tabIndex element focused", ":focus", [ "tmp_input" ]);
+		t("tabIndex element focused", ":focus", ["tmp_input"]);
 		ok(Sizzle.matchesSelector(tmp, ":focus"), ":focus matches tabIndex div");
 	}
 
@@ -861,12 +1600,16 @@ test("pseudo - misc", function(){
 	//input.focus();
 
 	// Inputs can't be focused unless the document has focus
-	if(document.activeElement !== input || (document.hasFocus && !document.hasFocus()) ||
-		(document.querySelectorAll && !document.querySelectorAll("input:focus").length)){
+	if(
+		document.activeElement !== input ||
+		(document.hasFocus && !document.hasFocus()) ||
+		(document.querySelectorAll &&
+			!document.querySelectorAll("input:focus").length)
+	){
 		ok(true, "The input was not focused. Skip checking the :focus match.");
 		ok(true, "The input was not focused. Skip checking the :focus match.");
 	} else {
-		t("Element focused", "input:focus", [ "focus-input" ]);
+		t("Element focused", "input:focus", ["focus-input"]);
 		ok(Sizzle.matchesSelector(input, ":focus"), ":focus matches");
 	}
 
@@ -880,31 +1623,53 @@ test("pseudo - misc", function(){
 	//ok( !Sizzle.matchesSelector( input, ":focus" ), ":focus doesn't match" );
 	document.body.children.pop();
 
-
-
 	deepEqual(
-		Sizzle("[id='select1'] *:not(:last-child), [id='select2'] *:not(:last-child)", q("qunit-fixture")[0]),
+		Sizzle(
+			"[id='select1'] *:not(:last-child), [id='select2'] *:not(:last-child)",
+			q("qunit-fixture")[0]
+		),
 		q("option1a", "option1b", "option1c", "option2a", "option2b", "option2c"),
 		"caching system tolerates recursive selection"
 	);
 
 	// Tokenization edge cases
-	t("Sequential pseudos", "#qunit-fixture p:has(:contains(mark)):has(code)", ["ap"]);
-	t("Sequential pseudos", "#qunit-fixture p:has(:contains(mark)):has(code):contains(This link)", ["ap"]);
+	t("Sequential pseudos", "#qunit-fixture p:has(:contains(mark)):has(code)", [
+		"ap"
+	]);
+	t(
+		"Sequential pseudos",
+		"#qunit-fixture p:has(:contains(mark)):has(code):contains(This link)",
+		["ap"]
+	);
 
 	t("Pseudo argument containing ')'", "p:has(>a.GROUPS[src!=')'])", ["ap"]);
 	t("Pseudo argument containing ')'", "p:has(>a.GROUPS[src!=')'])", ["ap"]);
-	t("Pseudo followed by token containing ')'", "p:contains(id=\"foo\")[id!=\\)]", ["sndp"]);
-	t("Pseudo followed by token containing ')'", "p:contains(id=\"foo\")[id!=')']", ["sndp"]);
+	t(
+		"Pseudo followed by token containing ')'",
+		"p:contains(id=\"foo\")[id!=\\)]",
+		["sndp"]
+	);
+	t(
+		"Pseudo followed by token containing ')'",
+		"p:contains(id=\"foo\")[id!=')']",
+		["sndp"]
+	);
 
 	t("Multi-pseudo", "#ap:has(*), #ap:has(*)", ["ap"]);
 	//t( "Multi-positional", "#ap:gt(0), #ap:lt(1)", ["ap"] );
-	t("Multi-pseudo with leading nonexistent id", "#nonexistent:has(*), #ap:has(*)", ["ap"]);
+	t(
+		"Multi-pseudo with leading nonexistent id",
+		"#nonexistent:has(*), #ap:has(*)",
+		["ap"]
+	);
 	//t( "Multi-positional with leading nonexistent id", "#nonexistent:gt(0), #ap:lt(1)", ["ap"] );
 
-	t("Tokenization stressor", "a[class*=blog]:not(:has(*, :contains(!)), :contains(!)), br:contains(]), p:contains(]), :not(:empty):not(:parent)", ["ap", "mark","yahoo","simon"]);
+	t(
+		"Tokenization stressor",
+		"a[class*=blog]:not(:has(*, :contains(!)), :contains(!)), br:contains(]), p:contains(]), :not(:empty):not(:parent)",
+		["ap", "mark", "yahoo", "simon"]
+	);
 });
-
 
 test("pseudo - :not", function(){
 	expect(43);
@@ -912,21 +1677,108 @@ test("pseudo - :not", function(){
 	t("Not", "a.blog:not(.link)", ["mark"]);
 	//t( ":not() with :first", "#foo p:not(:first) .link", ["simon"] );
 
-	t("Not - multiple", "#form option:not(:contains(Nothing),#option1b,:selected)", ["option1c", "option1d", "option2b", "option2c", "option3d", "option3e", "option4e", "option5b", "option5c"]);
-	t("Not - recursive", "#form option:not(:not(:selected))[id^='option3']", [ "option3b", "option3c"]);
+	t(
+		"Not - multiple",
+		"#form option:not(:contains(Nothing),#option1b,:selected)",
+		[
+			"option1c",
+			"option1d",
+			"option2b",
+			"option2c",
+			"option3d",
+			"option3e",
+			"option4e",
+			"option5b",
+			"option5c"
+		]
+	);
+	t("Not - recursive", "#form option:not(:not(:selected))[id^='option3']", [
+		"option3b",
+		"option3c"
+	]);
 
-	t(":not() failing interior", "#qunit-fixture p:not(.foo)", ["firstp","ap","sndp","en","sap","first"]);
-	t(":not() failing interior", "#qunit-fixture p:not(div.foo)", ["firstp","ap","sndp","en","sap","first"]);
-	t(":not() failing interior", "#qunit-fixture p:not(p.foo)", ["firstp","ap","sndp","en","sap","first"]);
-	t(":not() failing interior", "#qunit-fixture p:not(#blargh)", ["firstp","ap","sndp","en","sap","first"]);
-	t(":not() failing interior", "#qunit-fixture p:not(div#blargh)", ["firstp","ap","sndp","en","sap","first"]);
-	t(":not() failing interior", "#qunit-fixture p:not(p#blargh)", ["firstp","ap","sndp","en","sap","first"]);
+	t(":not() failing interior", "#qunit-fixture p:not(.foo)", [
+		"firstp",
+		"ap",
+		"sndp",
+		"en",
+		"sap",
+		"first"
+	]);
+	t(":not() failing interior", "#qunit-fixture p:not(div.foo)", [
+		"firstp",
+		"ap",
+		"sndp",
+		"en",
+		"sap",
+		"first"
+	]);
+	t(":not() failing interior", "#qunit-fixture p:not(p.foo)", [
+		"firstp",
+		"ap",
+		"sndp",
+		"en",
+		"sap",
+		"first"
+	]);
+	t(":not() failing interior", "#qunit-fixture p:not(#blargh)", [
+		"firstp",
+		"ap",
+		"sndp",
+		"en",
+		"sap",
+		"first"
+	]);
+	t(":not() failing interior", "#qunit-fixture p:not(div#blargh)", [
+		"firstp",
+		"ap",
+		"sndp",
+		"en",
+		"sap",
+		"first"
+	]);
+	t(":not() failing interior", "#qunit-fixture p:not(p#blargh)", [
+		"firstp",
+		"ap",
+		"sndp",
+		"en",
+		"sap",
+		"first"
+	]);
 
-	t(":not Multiple", "#qunit-fixture p:not(a)", ["firstp","ap","sndp","en","sap","first"]);
-	t(":not Multiple", "#qunit-fixture p:not( a )", ["firstp","ap","sndp","en","sap","first"]);
+	t(":not Multiple", "#qunit-fixture p:not(a)", [
+		"firstp",
+		"ap",
+		"sndp",
+		"en",
+		"sap",
+		"first"
+	]);
+	t(":not Multiple", "#qunit-fixture p:not( a )", [
+		"firstp",
+		"ap",
+		"sndp",
+		"en",
+		"sap",
+		"first"
+	]);
 	t(":not Multiple", "#qunit-fixture p:not( p )", []);
-	t(":not Multiple", "#qunit-fixture p:not(a, b)", ["firstp","ap","sndp","en","sap","first"]);
-	t(":not Multiple", "#qunit-fixture p:not(a, b, div)", ["firstp","ap","sndp","en","sap","first"]);
+	t(":not Multiple", "#qunit-fixture p:not(a, b)", [
+		"firstp",
+		"ap",
+		"sndp",
+		"en",
+		"sap",
+		"first"
+	]);
+	t(":not Multiple", "#qunit-fixture p:not(a, b, div)", [
+		"firstp",
+		"ap",
+		"sndp",
+		"en",
+		"sap",
+		"first"
+	]);
 	t(":not Multiple", "p:not(p)", []);
 	t(":not Multiple", "p:not(a,p)", []);
 	t(":not Multiple", "p:not(p,a)", []);
@@ -936,19 +1788,53 @@ test("pseudo - :not", function(){
 
 	t("No element not selector", ".container div:not(.excluded) div", []);
 
-	t(":not() Existing attribute", "#form select:not([multiple])", ["select1", "select2", "select5"]);
-	t(":not() Equals attribute", "#form select:not([name=select1])", ["select2", "select3", "select4","select5"]);
-	t(":not() Equals quoted attribute", "#form select:not([name='select1'])", ["select2", "select3", "select4", "select5"]);
+	t(":not() Existing attribute", "#form select:not([multiple])", [
+		"select1",
+		"select2",
+		"select5"
+	]);
+	t(":not() Equals attribute", "#form select:not([name=select1])", [
+		"select2",
+		"select3",
+		"select4",
+		"select5"
+	]);
+	t(":not() Equals quoted attribute", "#form select:not([name='select1'])", [
+		"select2",
+		"select3",
+		"select4",
+		"select5"
+	]);
 
 	t(":not() Multiple Class", "#foo a:not(.blog)", ["yahoo", "anchor2"]);
 	t(":not() Multiple Class", "#foo a:not(.link)", ["yahoo", "anchor2"]);
 	t(":not() Multiple Class", "#foo a:not(.blog.link)", ["yahoo", "anchor2"]);
 
-	t(":not chaining (compound)", "#qunit-fixture div[id]:not(:has(div, span)):not(:has(*))", ["nothiddendivchild", "divWithNoTabIndex"]);
-	t(":not chaining (with attribute)", "#qunit-fixture form[id]:not([action$='formaction']):not(:button)", ["lengthtest", "name-tests", "testForm"]);
-	t(":not chaining (colon in attribute)", "#qunit-fixture form[id]:not([action='form:action']):not(:button)", ["form", "lengthtest", "name-tests", "testForm"]);
-	t(":not chaining (colon in attribute and nested chaining)", "#qunit-fixture form[id]:not([action='form:action']:button):not(:input)", ["form", "lengthtest", "name-tests", "testForm"]);
-	t(":not chaining", "#form select:not(.select1):contains(Nothing) > option:not(option)", []);
+	t(
+		":not chaining (compound)",
+		"#qunit-fixture div[id]:not(:has(div, span)):not(:has(*))",
+		["nothiddendivchild", "divWithNoTabIndex"]
+	);
+	t(
+		":not chaining (with attribute)",
+		"#qunit-fixture form[id]:not([action$='formaction']):not(:button)",
+		["lengthtest", "name-tests", "testForm"]
+	);
+	t(
+		":not chaining (colon in attribute)",
+		"#qunit-fixture form[id]:not([action='form:action']):not(:button)",
+		["form", "lengthtest", "name-tests", "testForm"]
+	);
+	t(
+		":not chaining (colon in attribute and nested chaining)",
+		"#qunit-fixture form[id]:not([action='form:action']:button):not(:input)",
+		["form", "lengthtest", "name-tests", "testForm"]
+	);
+	t(
+		":not chaining",
+		"#form select:not(.select1):contains(Nothing) > option:not(option)",
+		[]
+	);
 
 	/*
 	t( "positional :not()", "#foo p:not(:last)", ["sndp", "en"] );
@@ -1016,19 +1902,74 @@ test("pseudo - position", function() {
 test("pseudo - form", function(){
 	expect(10);
 
-	var extraTexts = jQuery("<input id=\"impliedText\"/><input id=\"capitalText\" type=\"TEXT\">").appendTo("#form");
+	var extraTexts = jQuery(
+		"<input id=\"impliedText\"/><input id=\"capitalText\" type=\"TEXT\">"
+	).appendTo("#form");
 
-	t("Form element :input", "#form :input", ["text1", "text2", "radio1", "radio2", "check1", "check2", "hidden1", "hidden2", "name", "search", "button", "area1", "select1", "select2", "select3", "select4", "select5", "impliedText", "capitalText"]);
+	t("Form element :input", "#form :input", [
+		"text1",
+		"text2",
+		"radio1",
+		"radio2",
+		"check1",
+		"check2",
+		"hidden1",
+		"hidden2",
+		"name",
+		"search",
+		"button",
+		"area1",
+		"select1",
+		"select2",
+		"select3",
+		"select4",
+		"select5",
+		"impliedText",
+		"capitalText"
+	]);
 	t("Form element :radio", "#form :radio", ["radio1", "radio2"]);
 	t("Form element :checkbox", "#form :checkbox", ["check1", "check2"]);
-	t("Form element :text", "#form :text", ["text1", "text2", "hidden2", "name", "impliedText", "capitalText"]);
+	t("Form element :text", "#form :text", [
+		"text1",
+		"text2",
+		"hidden2",
+		"name",
+		"impliedText",
+		"capitalText"
+	]);
 	t("Form element :radio:checked", "#form :radio:checked", ["radio2"]);
 	t("Form element :checkbox:checked", "#form :checkbox:checked", ["check1"]);
-	t("Form element :radio:checked, :checkbox:checked", "#form :radio:checked, #form :checkbox:checked", ["radio2", "check1"]);
+	t(
+		"Form element :radio:checked, :checkbox:checked",
+		"#form :radio:checked, #form :checkbox:checked",
+		["radio2", "check1"]
+	);
 
-	t("Selected Option Element", "#form option:selected", ["option1a","option2d","option3b","option3c","option4b","option4c","option4d","option5a"]);
-	t("Selected Option Element are also :checked", "#form option:checked", ["option1a","option2d","option3b","option3c","option4b","option4c","option4d","option5a"]);
-	t("Hidden inputs should be treated as enabled. See QSA test.", "#hidden1:enabled", ["hidden1"]);
+	t("Selected Option Element", "#form option:selected", [
+		"option1a",
+		"option2d",
+		"option3b",
+		"option3c",
+		"option4b",
+		"option4c",
+		"option4d",
+		"option5a"
+	]);
+	t("Selected Option Element are also :checked", "#form option:checked", [
+		"option1a",
+		"option2d",
+		"option3b",
+		"option3c",
+		"option4b",
+		"option4c",
+		"option4d",
+		"option5a"
+	]);
+	t(
+		"Hidden inputs should be treated as enabled. See QSA test.",
+		"#hidden1:enabled",
+		["hidden1"]
+	);
 
 	extraTexts.remove();
 });
@@ -1160,7 +2101,11 @@ test("pseudo - :lang", function() {
 test("caching", function(){
 	expect(1);
 	Sizzle(":not(code)", document.getElementById("ap"));
-	deepEqual(Sizzle(":not(code)", document.getElementById("foo")), q("sndp", "en", "yahoo", "sap", "anchor2", "simon"), "Reusing selector with new context");
+	deepEqual(
+		Sizzle(":not(code)", document.getElementById("foo")),
+		q("sndp", "en", "yahoo", "sap", "anchor2", "simon"),
+		"Reusing selector with new context"
+	);
 });
 /*
 asyncTest( "Iframe dispatch should not affect Sizzle, see jQuery #13936", 1, function() {

--- a/test/test.js
+++ b/test/test.js
@@ -18,7 +18,6 @@ function exportsRun(mod){
 			describe(name, function(){
 				exportsRun(mod[name]);
 			});
-		}
-		else it(name, mod[name]);
+		} else it(name, mod[name]);
 	});
 }

--- a/test/tools/bench.js
+++ b/test/tools/bench.js
@@ -1,5 +1,6 @@
 var ben = require("ben"),
-	testString = "doo, *#foo > elem.bar[class$=bAz i]:not([ id *= \"2\" ]):nth-child(2n)",
+	testString =
+		"doo, *#foo > elem.bar[class$=bAz i]:not([ id *= \"2\" ]):nth-child(2n)",
 	helper = require("./helper.js"),
 	CSSselect = helper.CSSselect,
 	compile = CSSselect.compile,
@@ -7,4 +8,9 @@ var ben = require("ben"),
 
 //console.log("Parsing took:", ben(1e5, function(){compile(testString);}));
 var compiled = compile(testString);
-console.log("Executing took:", ben(1e6, function(){CSSselect(compiled, dom);}) * 1e3);
+console.log(
+	"Executing took:",
+	ben(1e6, function(){
+		CSSselect(compiled, dom);
+	}) * 1e3
+);

--- a/test/tools/slickspeed.js
+++ b/test/tools/slickspeed.js
@@ -2,14 +2,51 @@ var helper = require("./helper.js"),
 	doc = helper.getFile("W3C_Selectors.html"),
 	CSSselect = helper.CSSselect,
 	soupselect = require("cheerio-soupselect"),
-	selectors = ["body", "div", "body div", "div p", "div > p", "div + p", "div ~ p", "div[class^=exa][class$=mple]", "div p a", "div, p, a", ".note", "div.example", "ul .tocline2", "div.example, div.note", "#title", "h1#title", "div #title", "ul.toc li.tocline2", "ul.toc > li.tocline2", "h1#title + div > p", "h1[id]:contains(Selectors)", "a[href][lang][class]", "div[class]", "div[class=example]", "div[class^=exa]", "div[class$=mple]", "div[class*=e]", "div[class|=dialog]", "div[class!=made_up]", "div[class~=example]"/*, "div:not(.example)", "p:contains(selectors)", "p:nth-child(even)", "p:nth-child(2n)", "p:nth-child(odd)", "p:nth-child(2n+1)", "p:nth-child(n)", "p:only-child", "p:last-child", "p:first-child"*/];
+	selectors = [
+		"body",
+		"div",
+		"body div",
+		"div p",
+		"div > p",
+		"div + p",
+		"div ~ p",
+		"div[class^=exa][class$=mple]",
+		"div p a",
+		"div, p, a",
+		".note",
+		"div.example",
+		"ul .tocline2",
+		"div.example, div.note",
+		"#title",
+		"h1#title",
+		"div #title",
+		"ul.toc li.tocline2",
+		"ul.toc > li.tocline2",
+		"h1#title + div > p",
+		"h1[id]:contains(Selectors)",
+		"a[href][lang][class]",
+		"div[class]",
+		"div[class=example]",
+		"div[class^=exa]",
+		"div[class$=mple]",
+		"div[class*=e]",
+		"div[class|=dialog]",
+		"div[class!=made_up]",
+		"div[class~=example]" /*, "div:not(.example)", "p:contains(selectors)", "p:nth-child(even)", "p:nth-child(2n)", "p:nth-child(odd)", "p:nth-child(2n+1)", "p:nth-child(n)", "p:only-child", "p:last-child", "p:first-child"*/
+	];
 
-var engines = [function(a,b){return CSSselect(b,a);}, soupselect.select];
+var engines = [
+	function(a, b){
+		return CSSselect(b, a);
+	},
+	soupselect.select
+];
 
 //returns true when an error occurs
 function testResult(rule){
-	var results = engines
-		.map(function(func){ return func(doc, rule); });
+	var results = engines.map(function(func){
+		return func(doc, rule);
+	});
 
 	//check if both had the same result
 	for(var i = 1; i < results.length; i++){
@@ -31,7 +68,9 @@ function testResult(rule){
 	return false;
 }
 
-selectors.filter(testResult).forEach(function(rule){ print(rule, "failed!\n"); });
+selectors.filter(testResult).forEach(function(rule){
+	print(rule, "failed!\n");
+});
 
 process.exit(0); //don't run speed tests
 
@@ -43,12 +82,17 @@ var ben = require("ben");
 function testSpeed(rule){
 	print(rule, Array(28 - rule.length).join(" "));
 
-	var results = engines
-		.map(function(func){ return function(){ return func(doc, rule); }});
+	var results = engines.map(function(func){
+		return function(){
+			return func(doc, rule);
+		};
+	});
 
 	//also add a precompiled CSSselect test
 	var compiled = CSSselect(rule);
-	results.unshift(function(){ return CSSselect.iterate(compiled, doc); });
+	results.unshift(function(){
+		return CSSselect.iterate(compiled, doc);
+	});
 
 	results = results.map(ben);
 
@@ -67,7 +111,12 @@ function testSpeed(rule){
 	print("\n");
 }
 
-print("RULE                    ", "CSSselect (pc)", "CSSselect", "soupselect\n");
+print(
+	"RULE                    ",
+	"CSSselect (pc)",
+	"CSSselect",
+	"soupselect\n"
+);
 
 selectors.forEach(testSpeed);
 


### PR DESCRIPTION
This way there is no performance difference if another adapter is used.

Breaking change: Pseudos now take the adapter as the second argument,
and arguments as the third. Filters aren’t checked anymore if they have
the required number of arguments

Also formats most of the codebase with prettier.