### PR TITLE
Use a specific SPDX identifier for the license

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
     "lcov": "istanbul cover _mocha --report lcovonly -- -R spec",
     "coveralls": "npm run lint && npm run lcov && (cat coverage/lcov.info | coveralls || exit 0)"
   },
-  "license": "BSD-like",
+  "license": "BSD-2-Clause",
   "types": "index.d.ts"
 }


### PR DESCRIPTION
The `BSD-Like` isn't a valid [SPDX](https://spdx.org/licenses/) identifier and thus complicates auditing licenses and complying with them for anyone who uses `css-select` or any project depending on it.