### PR TITLE
New: Add `pseudos` that depend on optional Adapter APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,8 @@ _As defined by CSS 4 and / or jQuery._
   * `:[first|last]-child[-of-type]`
   * `:only-of-type`, `:only-child`
   * `:nth-[last-]child[-of-type]`
-  * `:link`, `:visited` (the latter doesn't match any elements)
+  * `:link`
+  * `:visited`, `:hover`, `:active` * (these depend on optional Adapter methods, so these will work only if implemented in Adapter)
   * `:selected` *, `:checked`
   * `:enabled`, `:disabled`
   * `:required`, `:optional`

--- a/index.d.ts
+++ b/index.d.ts
@@ -84,6 +84,21 @@ declare namespace CSSselect {
       `a === b`.
     */
     equals?: (a: Node, b: Node) => boolean;
+
+     /**
+     * is the element in hovered state?
+     */
+    isHovered?: (elem: ElementNode) => boolean;
+
+    /**
+     * is the element in visited state?
+     */
+    isVisited?: (elem: ElementNode) => boolean;
+
+    /**
+     * is the element in active state?
+     */
+    isActive?: (elem: ElementNode) => boolean;
   }
 
   // TODO default types to the domutil/httpparser2 types

--- a/lib/pseudos.js
+++ b/lib/pseudos.js
@@ -179,7 +179,42 @@ var filters = {
     radio: getAttribFunc("type", "radio"),
     reset: getAttribFunc("type", "reset"),
     image: getAttribFunc("type", "image"),
-    submit: getAttribFunc("type", "submit")
+    submit: getAttribFunc("type", "submit"),
+
+    //dynamic state pseudos. These depend on optional Adapter methods.
+    hover: function(next, rule, options) {
+        var adapter = options.adapter;
+
+        if (typeof adapter.isHovered === 'function') {
+            return function hover(elem) {
+                return next(elem) && adapter.isHovered(elem);
+            };
+        }
+
+        return falseFunc;
+    },
+    visited: function(next, rule, options) {
+        var adapter = options.adapter;
+
+        if (typeof adapter.isVisited === 'function') {
+            return function visited(elem) {
+                return next(elem) && adapter.isVisited(elem);
+            };
+        }
+
+        return falseFunc;
+    },
+    active: function(next, rule, options) {
+        var adapter = options.adapter;
+
+        if (typeof adapter.isActive === 'function') {
+            return function active(elem) {
+                return next(elem) && adapter.isActive(elem);
+            };
+        }
+
+        return falseFunc;
+    }
 };
 
 //helper methods
@@ -188,13 +223,6 @@ function getFirstElement(elems, adapter) {
         if (adapter.isTag(elems[i])) return elems[i];
     }
 }
-
-//pseudos that depends on optional Adapter methods. (key, value) = (pseudoName, adapterMethod)
-var pseudosWithOptionalImplementation = {
-    hover: "isHovered",
-    visited: "isVisited",
-    active: "isActive"
-};
 
 //while filters are precompiled, pseudos get called when they are needed
 var pseudos = {
@@ -268,24 +296,6 @@ var pseudos = {
     //:matches(a, area, link)[href]
     link: function(elem, adapter) {
         return adapter.hasAttrib(elem, "href");
-    },
-    hover: function(elem, adapter) {
-        if (adapter.isHovered) {
-            return adapter.isHovered(elem);
-        }
-        return false;
-    },
-    visited: function(elem, adapter) {
-        if (adapter.isVisited) {
-            return adapter.isVisited(elem);
-        }
-        return false;
-    },
-    active: function(elem, adapter) {
-        if (adapter.isActive) {
-            return adapter.isActive(elem);
-        }
-        return false;
     },
     //TODO: :any-link once the name is finalized (as an alias of :link)
 
@@ -417,18 +427,7 @@ module.exports = {
         if (typeof filters[name] === "function") {
             return filters[name](next, subselect, options, context);
         } else if (typeof pseudos[name] === "function") {
-            var func;
-            var optionalAdapterMethod = pseudosWithOptionalImplementation[name];
-
-            if (optionalAdapterMethod) {
-                if (typeof adapter[optionalAdapterMethod] === 'function') {
-                    func = pseudos[name];
-                } else {
-                    func = falseFunc;
-                }
-            } else {
-                func = pseudos[name];
-            }
+            var func = pseudos[name];
 
             verifyArgs(func, name, subselect);
 

--- a/lib/pseudos.js
+++ b/lib/pseudos.js
@@ -189,6 +189,13 @@ function getFirstElement(elems, adapter) {
     }
 }
 
+//pseudos that depends on optional Adapter methods. (key, value) = (pseudoName, adapterMethod)
+var pseudosWithOptionalImplementation = {
+    hover: "isHovered",
+    visited: "isVisited",
+    active: "isActive"
+};
+
 //while filters are precompiled, pseudos get called when they are needed
 var pseudos = {
     empty: function(elem, adapter) {
@@ -262,7 +269,24 @@ var pseudos = {
     link: function(elem, adapter) {
         return adapter.hasAttrib(elem, "href");
     },
-    visited: falseFunc, //Valid implementation
+    hover: function(elem, adapter) {
+        if (adapter.isHovered) {
+            return adapter.isHovered(elem);
+        }
+        return false;
+    },
+    visited: function(elem, adapter) {
+        if (adapter.isVisited) {
+            return adapter.isVisited(elem);
+        }
+        return false;
+    },
+    active: function(elem, adapter) {
+        if (adapter.isActive) {
+            return adapter.isActive(elem);
+        }
+        return false;
+    },
     //TODO: :any-link once the name is finalized (as an alias of :link)
 
     //forms
@@ -393,7 +417,19 @@ module.exports = {
         if (typeof filters[name] === "function") {
             return filters[name](next, subselect, options, context);
         } else if (typeof pseudos[name] === "function") {
-            var func = pseudos[name];
+            var func;
+            var optionalAdapterMethod = pseudosWithOptionalImplementation[name];
+
+            if (optionalAdapterMethod) {
+                if (typeof adapter[optionalAdapterMethod] === 'function') {
+                    func = pseudos[name];
+                } else {
+                    func = falseFunc;
+                }
+            } else {
+                func = pseudos[name];
+            }
+
             verifyArgs(func, name, subselect);
 
             if (func === falseFunc) {

--- a/test/qwery/index.js
+++ b/test/qwery/index.js
@@ -442,6 +442,18 @@ module.exports = {
             location.hash = "";
         },
 
+        ":hover": function() {
+            expect(CSSselect("#pseudos div:hover", document)).to.be.empty();
+        },
+
+        ":active": function() {
+            expect(CSSselect("#pseudos div:active", document)).to.be.empty();
+        },
+
+        ":visited": function() {
+            expect(CSSselect("#pseudos div:visited", document)).to.be.empty();
+        },
+
         "custom pseudos": function() {
             // :humanoid implemented just for testing purposes
             expect(CSSselect(":humanoid", document)).to.have.length(2); //selected using custom pseudo


### PR DESCRIPTION
Pseudos like element state `hover`, `active`, `visited`, etc can be supported conditionally.

This PR enables such pseudos to be supported only if associated Adapter method is implemented.

For example:
`hover` pseudo may give results, only if `isHovered` is implemented in given Adapter APIs. Otherwise, `hover` will result into `falseFunc` and will give empty result.

This logic can be improved in various ways. Please review once and see my comments on code and let me know if I am going in right direction.

I will be updating `Readme` and Test Cases once logic is finalised.

Resolves: #80