### PR TITLE
fix: :scope not matching when selecting in a scope

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -65,7 +65,7 @@ function absolutize(token, options, context) {
     token.forEach(function(t) {
         if (t.length > 0 && isTraversal(t[0]) && t[0].type !== "descendant") {
             //don't return in else branch
-        } else if (hasContext && !includesScopePseudo(t)) {
+        } else if (hasContext && !(Array.isArray(t) ? t.some(includesScopePseudo) : includesScopePseudo(t))) {
             t.unshift(DESCENDANT_TOKEN);
         } else {
             return;

--- a/test/sizzle/data/index.html
+++ b/test/sizzle/data/index.html
@@ -242,6 +242,9 @@ Z</textarea>
 		</div>​
 	</div>
 	</dl>
+	<div id="scopeTest">
+		<label id="scopeTest--child"></label>
+	</div>
 	<br id="last"/>
 </body>
 </html>

--- a/test/sizzle/selector.js
+++ b/test/sizzle/selector.js
@@ -671,6 +671,11 @@ test("child and adjacent", function() {
     //deepEqual( Sizzle("> *:first", nothiddendiv), q("nothiddendivchild"), "Verify child context positional selector" );
 
     t("Non-existant ancestors", ".fototab > .thumbnails > a", []);
+    deepEqual(
+        CSSselect.selectOne(':scope > label', CSSselect.selectOne('#scopeTest', document)),
+        CSSselect.selectOne('#scopeTest--child', document),
+        "Child of scope"
+    );
 });
 
 test("attributes", function() {


### PR DESCRIPTION
`:scope > label` was absolutized into `:scope :scope > label` when used in a scope i.e. when using `selectOne(':scope > label', selectOne('#scope'))`

I don't understand the current terminology since items of a `token` are named `t` and I suspect the error originates from somewhere else. But at least it fixed the test which is valid in a browser: 
1. Goto https://o9vrw.csb.app/
2. Enter `:scope > label`
3. DOM will output HTMLLabelElement while css-select returns null

Code available in https://codesandbox.io/s/css-select-vs-elementqueryselector-o9vrw