### PR TITLE
Show optional `CSSselect.compile` options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Queries `elems`, returns an array containing all matches.
 
 Aliases: `default` export, `CSSselect.iterate(query, elems)`.
 
-#### `CSSselect.compile(query)`
+#### `CSSselect.compile(query, options)`
 
 Compiles the query, returns a function.
 


### PR DESCRIPTION
First of all, thanks for this library, and thanks in advance for eventually considering this change.

It took me way too long to figure out why `CSSselect.compile(selectors)` was not working, and I was passing it as `CSSselect.is(selector, compiledFN, options)`, as opposite of simply compiling the selector once through the options, and use that function directly.

This tiny change might help other developers that, like me, could be not so sure how to use compile.