### PR TITLE
fix(attributes): Fix `!=` ignoring elements without attribute

### DIFF
--- a/src/attributes.ts
+++ b/src/attributes.ts
@@ -162,15 +162,9 @@ export const attributeRules: Record<
         } else if (data.ignoreCase) {
             value = value.toLowerCase();
 
-            return (elem) => {
-                const attr = adapter.getAttributeValue(elem, name);
-
-                return (
-                    attr != null &&
-                    attr.toLocaleLowerCase() !== value &&
-                    next(elem)
-                );
-            };
+            return (elem) =>
+                adapter.getAttributeValue(elem, name)?.toLowerCase() !==
+                    value && next(elem);
         }
 
         return (elem) =>

--- a/src/attributes.ts
+++ b/src/attributes.ts
@@ -31,9 +31,15 @@ export const attributeRules: Record<
         if (data.ignoreCase) {
             value = value.toLowerCase();
 
-            return (elem) =>
-                adapter.getAttributeValue(elem, name)?.toLowerCase() ===
-                    value && next(elem);
+            return (elem) => {
+                const attr = adapter.getAttributeValue(elem, name);
+                return (
+                    attr != null &&
+                    attr.length === value.length &&
+                    attr.toLowerCase() === value &&
+                    next(elem)
+                );
+            };
         }
 
         return (elem) =>
@@ -51,6 +57,7 @@ export const attributeRules: Record<
                 const attr = adapter.getAttributeValue(elem, name);
                 return (
                     attr != null &&
+                    attr.length >= len &&
                     (attr.length === len || attr.charAt(len) === "-") &&
                     attr.substr(0, len).toLowerCase() === value &&
                     next(elem)
@@ -62,6 +69,7 @@ export const attributeRules: Record<
             const attr = adapter.getAttributeValue(elem, name);
             return (
                 attr != null &&
+                attr.length >= len &&
                 attr.substr(0, len) === value &&
                 (attr.length === len || attr.charAt(len) === "-") &&
                 next(elem)
@@ -80,7 +88,12 @@ export const attributeRules: Record<
 
         return function element(elem) {
             const attr = adapter.getAttributeValue(elem, name);
-            return attr != null && regex.test(attr) && next(elem);
+            return (
+                attr != null &&
+                attr.length >= value.length &&
+                regex.test(attr) &&
+                next(elem)
+            );
         };
     },
     exists(next, { name }, { adapter }) {
@@ -98,11 +111,15 @@ export const attributeRules: Record<
         if (data.ignoreCase) {
             value = value.toLowerCase();
 
-            return (elem) =>
-                adapter
-                    .getAttributeValue(elem, name)
-                    ?.substr(0, len)
-                    .toLowerCase() === value && next(elem);
+            return (elem) => {
+                const attr = adapter.getAttributeValue(elem, name);
+                return (
+                    attr != null &&
+                    attr.length >= len &&
+                    attr.substr(0, len).toLowerCase() === value &&
+                    next(elem)
+                );
+            };
         }
 
         return (elem) =>
@@ -144,7 +161,12 @@ export const attributeRules: Record<
 
             return function anyIC(elem) {
                 const attr = adapter.getAttributeValue(elem, name);
-                return attr != null && regex.test(attr) && next(elem);
+                return (
+                    attr != null &&
+                    attr.length >= value.length &&
+                    regex.test(attr) &&
+                    next(elem)
+                );
             };
         }
 
@@ -162,9 +184,15 @@ export const attributeRules: Record<
         } else if (data.ignoreCase) {
             value = value.toLowerCase();
 
-            return (elem) =>
-                adapter.getAttributeValue(elem, name)?.toLowerCase() !==
-                    value && next(elem);
+            return (elem) => {
+                const attr = adapter.getAttributeValue(elem, name);
+                return (
+                    (attr == null ||
+                        attr.length !== value.length ||
+                        attr.toLowerCase() !== value) &&
+                    next(elem)
+                );
+            };
         }
 
         return (elem) =>

--- a/test/attributes.ts
+++ b/test/attributes.ts
@@ -48,7 +48,7 @@ describe("Attributes", () => {
                 '[data-foo!="indeed-that\'s a delicate matter." i]',
                 dom
             );
-            expect(matches).toHaveLength(1);
+            expect(matches).toHaveLength(2);
             expect(matches).toStrictEqual([dom[0].children[0] as Element]);
             matches = CSSselect.selectAll(
                 '[data-foo!="inDeeD-THAT\'s a DELICATE matteR." i]',

--- a/test/attributes.ts
+++ b/test/attributes.ts
@@ -1,11 +1,12 @@
 import * as CSSselect from "../src";
-import { parseDOM } from "htmlparser2";
+import { parseDocument } from "htmlparser2";
 import { falseFunc } from "boolbase";
 import type { Element } from "domhandler";
 
-const dom = parseDOM(
-    '<div><div data-foo="In the end, it doesn\'t really matter."></div><div data-foo="Indeed-that\'s a delicate matter.">'
-) as Element[];
+const dom = parseDocument(
+    '<div data-foo="In the end, it doesn\'t really matter."></div><div data-foo="Indeed-that\'s a delicate matter.">'
+);
+const domChilds = dom.children as Element[];
 
 describe("Attributes", () => {
     describe("ignore case", () => {
@@ -15,32 +16,32 @@ describe("Attributes", () => {
                 dom
             );
             expect(matches).toHaveLength(1);
-            expect(matches).toStrictEqual([dom[0].children[1] as Element]);
+            expect(matches).toStrictEqual([domChilds[1]]);
             matches = CSSselect.selectAll(
                 '[data-foo="inDeeD-THAT\'s a DELICATE matteR." i]',
                 dom
             );
-            expect(matches).toStrictEqual([dom[0].children[1] as Element]);
+            expect(matches).toStrictEqual([domChilds[1]]);
         });
 
         it("should for ^=", () => {
             let matches = CSSselect.selectAll("[data-foo^=IN i]", dom);
             expect(matches).toHaveLength(2);
-            expect(matches).toStrictEqual(dom[0].children as Element[]);
+            expect(matches).toStrictEqual(domChilds);
             matches = CSSselect.selectAll("[data-foo^=in i]", dom);
-            expect(matches).toStrictEqual(dom[0].children as Element[]);
+            expect(matches).toStrictEqual(domChilds);
             matches = CSSselect.selectAll("[data-foo^=iN i]", dom);
-            expect(matches).toStrictEqual(dom[0].children as Element[]);
+            expect(matches).toStrictEqual(domChilds);
         });
 
         it("should for $=", () => {
             let matches = CSSselect.selectAll('[data-foo$="MATTER." i]', dom);
             expect(matches).toHaveLength(2);
-            expect(matches).toStrictEqual(dom[0].children as Element[]);
+            expect(matches).toStrictEqual(domChilds);
             matches = CSSselect.selectAll('[data-foo$="matter." i]', dom);
-            expect(matches).toStrictEqual(dom[0].children as Element[]);
+            expect(matches).toStrictEqual(domChilds);
             matches = CSSselect.selectAll('[data-foo$="MaTtEr." i]', dom);
-            expect(matches).toStrictEqual(dom[0].children as Element[]);
+            expect(matches).toStrictEqual(domChilds);
         });
 
         it("should for !=", () => {
@@ -48,37 +49,37 @@ describe("Attributes", () => {
                 '[data-foo!="indeed-that\'s a delicate matter." i]',
                 dom
             );
-            expect(matches).toHaveLength(2);
-            expect(matches).toStrictEqual([dom[0].children[0] as Element]);
+            expect(matches).toHaveLength(1);
+            expect(matches).toStrictEqual([domChilds[0]]);
             matches = CSSselect.selectAll(
                 '[data-foo!="inDeeD-THAT\'s a DELICATE matteR." i]',
                 dom
             );
-            expect(matches).toStrictEqual([dom[0].children[0] as Element]);
+            expect(matches).toStrictEqual([domChilds[0]]);
         });
 
         it("should for *=", () => {
             let matches = CSSselect.selectAll("[data-foo*=IT i]", dom);
             expect(matches).toHaveLength(1);
-            expect(matches).toStrictEqual([dom[0].children[0] as Element]);
+            expect(matches).toStrictEqual([domChilds[0]]);
             matches = CSSselect.selectAll("[data-foo*=tH i]", dom);
-            expect(matches).toStrictEqual(dom[0].children as Element[]);
+            expect(matches).toStrictEqual(domChilds);
         });
 
         it("should for |=", () => {
             let matches = CSSselect.selectAll("[data-foo|=indeed i]", dom);
             expect(matches).toHaveLength(1);
-            expect(matches).toStrictEqual([dom[0].children[1] as Element]);
+            expect(matches).toStrictEqual([domChilds[1]]);
             matches = CSSselect.selectAll("[data-foo|=inDeeD i]", dom);
-            expect(matches).toStrictEqual([dom[0].children[1] as Element]);
+            expect(matches).toStrictEqual([domChilds[1]]);
         });
 
         it("should for ~=", () => {
             let matches = CSSselect.selectAll("[data-foo~=IT i]", dom);
             expect(matches).toHaveLength(1);
-            expect(matches).toStrictEqual([dom[0].children[0] as Element]);
+            expect(matches).toStrictEqual([domChilds[0]]);
             matches = CSSselect.selectAll("[data-foo~=dElIcAtE i]", dom);
-            expect(matches).toStrictEqual([dom[0].children[1] as Element]);
+            expect(matches).toStrictEqual([domChilds[1]]);
         });
     });
 


### PR DESCRIPTION
When `ignoreCase` is `true`.

Necessary for #390