### PR TITLE
feat(pseudos): Introduce aliases

### DIFF
--- a/src/attributes.ts
+++ b/src/attributes.ts
@@ -57,7 +57,6 @@ export const attributeRules: Record<
                 const attr = adapter.getAttributeValue(elem, name);
                 return (
                     attr != null &&
-                    attr.length >= len &&
                     (attr.length === len || attr.charAt(len) === "-") &&
                     attr.substr(0, len).toLowerCase() === value &&
                     next(elem)
@@ -69,9 +68,8 @@ export const attributeRules: Record<
             const attr = adapter.getAttributeValue(elem, name);
             return (
                 attr != null &&
-                attr.length >= len &&
-                attr.substr(0, len) === value &&
                 (attr.length === len || attr.charAt(len) === "-") &&
+                attr.substr(0, len) === value &&
                 next(elem)
             );
         };

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -62,7 +62,10 @@ function absolutize<Node, ElementNode extends Node>(
     // TODO Use better check if the context is a document
     const hasContext = !!context?.every((e) => {
         const parent = adapter.getParent(e);
-        return e === PLACEHOLDER_ELEMENT || !!(parent && adapter.isTag(parent));
+        return (
+            e === PLACEHOLDER_ELEMENT ||
+            (parent != null && adapter.isTag(parent))
+        );
     });
 
     for (const t of token) {

--- a/src/general.ts
+++ b/src/general.ts
@@ -100,7 +100,7 @@ export function compileGeneralSelector<Node, ElementNode extends Node>(
         case "child":
             return function child(elem: ElementNode): boolean {
                 const parent = adapter.getParent(elem);
-                return !!parent && adapter.isTag(parent) && next(parent);
+                return parent != null && adapter.isTag(parent) && next(parent);
             };
 
         case "sibling":

--- a/src/index.ts
+++ b/src/index.ts
@@ -192,5 +192,5 @@ export function is<Node, ElementNode extends Node>(
  */
 export default selectAll;
 
-// Export filters and pseudos to allow users to supply their own.
-export { filters, pseudos } from "./pseudo-selectors";
+// Export filters, pseudos and aliases to allow users to supply their own.
+export { filters, pseudos, aliases } from "./pseudo-selectors";

--- a/src/pseudo-selectors/aliases.ts
+++ b/src/pseudo-selectors/aliases.ts
@@ -1,0 +1,44 @@
+/**
+ * Aliases are pseudos that are expressed as selectors.
+ */
+export const aliases: Record<string, string> = {
+    // Links
+
+    "any-link": ":is(a, area, link)[href]",
+    link: ":any-link:not(:visited)",
+
+    // Forms
+
+    // https://html.spec.whatwg.org/multipage/scripting.html#disabled-elements
+    disabled: `:is(
+        :is(button, input, select, textarea, optgroup, option)[disabled],
+        optgroup[disabled] > option,
+        fieldset[disabled]:not(fieldset[disabled] legend:first-of-type *)
+    )`,
+    enabled: ":not(:disabled)",
+    checked:
+        ":is(:is(input[type=radio], input[type=checkbox])[checked], option:selected)",
+    required: ":is(input, select, textarea)[required]",
+    optional: ":is(input, select, textarea):not([required])",
+
+    // JQuery extensions
+
+    // https://html.spec.whatwg.org/multipage/form-elements.html#concept-option-selectedness
+    selected:
+        "option:is([selected], select:not([multiple]):not(:has(> option[selected])) > :first-of-type)",
+
+    checkbox: "[type=checkbox]",
+    file: "[type=file]",
+    password: "[type=password]",
+    radio: "[type=radio]",
+    reset: "[type=reset]",
+    image: "[type=image]",
+    submit: "[type=submit]",
+
+    parent: ":not(:empty)",
+    header: ":is(h1, h2, h3, h4, h5, h6)",
+
+    button: ":is(button, input[type=button])",
+    input: ":is(input, textarea, select, button)",
+    text: "input:is(:not([type!='']), [type=text])",
+};

--- a/src/pseudo-selectors/pseudos.ts
+++ b/src/pseudo-selectors/pseudos.ts
@@ -7,8 +7,6 @@ export type Pseudo = <Node, ElementNode extends Node>(
     subselect?: ElementNode | string | null
 ) => boolean;
 
-const isLinkTag = namePseudo(["a", "area", "link"]);
-
 // While filters are precompiled, pseudos get called when they are needed
 export const pseudos: Record<string, Pseudo> = {
     empty(elem, { adapter }) {
@@ -88,130 +86,7 @@ export const pseudos: Record<string, Pseudo> = {
                 (sibling) => equals(elem, sibling) || !adapter.isTag(sibling)
             );
     },
-
-    // :is(a, area, link)[href]
-    "any-link"(elem, options) {
-        return (
-            isLinkTag(elem, options) && options.adapter.hasAttrib(elem, "href")
-        );
-    },
-    // :any-link:not(:visited)
-    link(elem, options) {
-        return (
-            options.adapter.isVisited?.(elem) !== true &&
-            pseudos["any-link"](elem, options)
-        );
-    },
-
-    /*
-     * Forms
-     * to consider: :target
-     */
-
-    // :is([selected], select:not([multiple]):not(> option[selected]) > option:first-of-type)
-    selected(elem, { adapter, equals }) {
-        if (adapter.hasAttrib(elem, "selected")) return true;
-        else if (adapter.getName(elem) !== "option") return false;
-
-        // The first <option> in a <select> is also selected
-        const parent = adapter.getParent(elem);
-
-        if (
-            !parent ||
-            !adapter.isTag(parent) ||
-            adapter.getName(parent) !== "select" ||
-            adapter.hasAttrib(parent, "multiple")
-        ) {
-            return false;
-        }
-
-        const siblings = adapter.getChildren(parent);
-        let sawElem = false;
-
-        for (let i = 0; i < siblings.length; i++) {
-            const currentSibling = siblings[i];
-            if (adapter.isTag(currentSibling)) {
-                if (equals(elem, currentSibling)) {
-                    sawElem = true;
-                } else if (!sawElem) {
-                    return false;
-                } else if (adapter.hasAttrib(currentSibling, "selected")) {
-                    return false;
-                }
-            }
-        }
-
-        return sawElem;
-    },
-    /*
-     * https://html.spec.whatwg.org/multipage/scripting.html#disabled-elements
-     * :is(
-     *   :is(button, input, select, textarea, optgroup, option)[disabled],
-     *   optgroup[disabled] > option,
-     *   fieldset[disabled] :not(fieldset[disabled] legend:first-child *)
-     * )
-     */
-    disabled(elem, { adapter }) {
-        return adapter.hasAttrib(elem, "disabled");
-    },
-    enabled(elem, { adapter }) {
-        return !adapter.hasAttrib(elem, "disabled");
-    },
-    // :is(:is(input[type=radio], input[type=checkbox])[checked], option:selected)
-    checked(elem, options) {
-        return (
-            options.adapter.hasAttrib(elem, "checked") ||
-            pseudos.selected(elem, options)
-        );
-    },
-    // :is(input, select, textarea)[required]
-    required(elem, { adapter }) {
-        return adapter.hasAttrib(elem, "required");
-    },
-    // :is(input, select, textarea):not([required])
-    optional(elem, { adapter }) {
-        return !adapter.hasAttrib(elem, "required");
-    },
-
-    // JQuery extensions
-
-    // :not(:empty)
-    parent(elem, options) {
-        return !pseudos.empty(elem, options);
-    },
-    // :is(h1, h2, h3, h4, h5, h6)
-    header: namePseudo(["h1", "h2", "h3", "h4", "h5", "h6"]),
-
-    // :is(button, input[type=button])
-    button(elem, { adapter }) {
-        const name = adapter.getName(elem);
-        return (
-            name === "button" ||
-            (name === "input" &&
-                adapter.getAttributeValue(elem, "type") === "button")
-        );
-    },
-    // :is(input, textarea, select, button)
-    input: namePseudo(["input", "textarea", "select", "button"]),
-    // `input:is([type=''], [type=text])`
-    text(elem, { adapter }) {
-        const type = adapter.getAttributeValue(elem, "type");
-        return (
-            adapter.getName(elem) === "input" &&
-            (!type || type.toLowerCase() === "text")
-        );
-    },
 };
-
-function namePseudo(names: string[]): Pseudo {
-    if (typeof Set !== "undefined") {
-        const nameSet = new Set(names);
-
-        return (elem, { adapter }) => nameSet.has(adapter.getName(elem));
-    }
-
-    return (elem, { adapter }) => names.includes(adapter.getName(elem));
-}
 
 export function verifyPseudoArgs(
     func: Pseudo,
@@ -219,14 +94,10 @@ export function verifyPseudoArgs(
     subselect: PseudoSelector["data"]
 ): void {
     if (subselect === null) {
-        if (func.length > 2 && name !== "scope") {
+        if (func.length > 2) {
             throw new Error(`pseudo-selector :${name} requires an argument`);
         }
-    } else {
-        if (func.length === 2) {
-            throw new Error(
-                `pseudo-selector :${name} doesn't have any arguments`
-            );
-        }
+    } else if (func.length === 2) {
+        throw new Error(`pseudo-selector :${name} doesn't have any arguments`);
     }
 }

--- a/test/api.ts
+++ b/test/api.ts
@@ -62,6 +62,10 @@ describe("API", () => {
             expect(() => CSSselect.compile(":any-link(test)")).toThrow(
                 "doesn't have any arguments"
             );
+
+            expect(() => CSSselect.compile(":only-child(test)")).toThrow(
+                "doesn't have any arguments"
+            );
         });
 
         it("should throw if no parameter is supplied for pseudo", () => {
@@ -117,6 +121,33 @@ describe("API", () => {
             );
             expect(matches).toHaveLength(1);
             expect(matches[0]).toBe(dom);
+        });
+
+        it("should support traversals", () => {
+            let matches = CSSselect.selectAll(":matches(div p)", [dom]);
+            expect(matches).toHaveLength(1);
+            expect(matches[0].name).toBe("p");
+
+            matches = CSSselect.selectAll(":matches(div > p)", [dom]);
+            expect(matches).toHaveLength(1);
+            expect(matches[0].name).toBe("p");
+
+            matches = CSSselect.selectAll(":matches(p < div)", [dom]);
+            expect(matches).toHaveLength(1);
+            expect(matches[0].name).toBe("div");
+
+            matches = CSSselect.selectAll(":matches(> p)", [dom]);
+            expect(matches).toHaveLength(1);
+            expect(matches[0].name).toBe("p");
+
+            matches = CSSselect.selectAll("div:has(:is(:scope p))", [dom]);
+            expect(matches).toHaveLength(1);
+            expect(matches[0].name).toBe("div");
+
+            const [multiLevelDom] = parseDOM("<a><b><c><d>") as Element[];
+            matches = CSSselect.selectAll(":is(* c)", multiLevelDom);
+            expect(matches).toHaveLength(1);
+            expect(matches[0].name).toBe("c");
         });
 
         it("should support alias :is", () => {


### PR DESCRIPTION
Aliases are pseudos that can be expressed as a selector.

Corrects the implementation for several pseudos, eg. `:disabled`, `:checked` and `:required`.

Also fixes `:is` with traversals.