### PR TITLE
refactor: Allow plain nodes as context

### DIFF
--- a/src/compile.ts
+++ b/src/compile.ts
@@ -29,7 +29,7 @@ export function compile<Node, ElementNode extends Node>(
 export function compileUnsafe<Node, ElementNode extends Node>(
     selector: string | Selector[][],
     options: InternalOptions<Node, ElementNode>,
-    context?: ElementNode[] | ElementNode
+    context?: Node[] | Node
 ): CompiledQuery<ElementNode> {
     const token =
         typeof selector === "string" ? parse(selector, options) : selector;
@@ -58,15 +58,12 @@ const SCOPE_TOKEN: Selector = { type: "pseudo", name: "scope", data: null };
 function absolutize<Node, ElementNode extends Node>(
     token: InternalSelector[][],
     { adapter }: InternalOptions<Node, ElementNode>,
-    context?: ElementNode[]
+    context?: Node[]
 ) {
     // TODO Use better check if the context is a document
     const hasContext = !!context?.every((e) => {
-        const parent = adapter.getParent(e);
-        return (
-            e === PLACEHOLDER_ELEMENT ||
-            (parent != null && adapter.isTag(parent))
-        );
+        const parent = adapter.isTag(e) && adapter.getParent(e);
+        return e === PLACEHOLDER_ELEMENT || (parent && adapter.isTag(parent));
     });
 
     for (const t of token) {
@@ -85,7 +82,7 @@ function absolutize<Node, ElementNode extends Node>(
 export function compileToken<Node, ElementNode extends Node>(
     token: InternalSelector[][],
     options: InternalOptions<Node, ElementNode>,
-    context?: ElementNode[] | ElementNode
+    context?: Node[] | Node
 ): CompiledQuery<ElementNode> {
     token = token.filter((t) => t.length > 0);
 
@@ -134,7 +131,7 @@ export function compileToken<Node, ElementNode extends Node>(
 function compileRules<Node, ElementNode extends Node>(
     rules: InternalSelector[],
     options: InternalOptions<Node, ElementNode>,
-    context?: ElementNode[]
+    context?: Node[]
 ): CompiledQuery<ElementNode> {
     return rules.reduce<CompiledQuery<ElementNode>>(
         (previous, rule) =>

--- a/src/general.ts
+++ b/src/general.ts
@@ -15,7 +15,7 @@ export function compileGeneralSelector<Node, ElementNode extends Node>(
     next: CompiledQuery<ElementNode>,
     selector: InternalSelector,
     options: InternalOptions<Node, ElementNode>,
-    context: ElementNode[] | undefined,
+    context: Node[] | undefined,
     compileToken: CompileToken<Node, ElementNode>
 ): CompiledQuery<ElementNode> {
     const { adapter, equals } = options;

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,7 +73,7 @@ function getSelectorFunc<Node, ElementNode extends Node, T>(
 ) {
     return function select(
         query: Query<ElementNode>,
-        elements: ElementNode[] | ElementNode,
+        elements: Node[] | Node,
         options?: Options<Node, ElementNode>
     ): T {
         const opts = convertOptionFormats(options);
@@ -92,7 +92,7 @@ function getSelectorFunc<Node, ElementNode extends Node, T>(
 }
 
 export function prepareContext<Node, ElementNode extends Node>(
-    elems: ElementNode | ElementNode[],
+    elems: Node | Node[],
     adapter: Adapter<Node, ElementNode>,
     shouldTestNextSiblings = false
 ): Node[] {
@@ -110,9 +110,9 @@ export function prepareContext<Node, ElementNode extends Node>(
 }
 
 function appendNextSiblings<Node, ElementNode extends Node>(
-    elem: ElementNode | ElementNode[],
+    elem: Node | Node[],
     adapter: Adapter<Node, ElementNode>
-): ElementNode[] {
+): Node[] {
     // Order matters because jQuery seems to check the children before the siblings
     const elems = Array.isArray(elem) ? elem.slice(0) : [elem];
 

--- a/src/pseudo-selectors/filters.ts
+++ b/src/pseudo-selectors/filters.ts
@@ -6,7 +6,7 @@ export type Filter = <Node, ElementNode extends Node>(
     next: CompiledQuery<ElementNode>,
     text: string,
     options: InternalOptions<Node, ElementNode>,
-    context?: ElementNode[]
+    context?: Node[]
 ) => CompiledQuery<ElementNode>;
 
 function getChildFunc<Node, ElementNode extends Node>(
@@ -138,7 +138,7 @@ export const filters: Record<string, Filter> = {
         next: CompiledQuery<ElementNode>,
         rule: string,
         options: InternalOptions<Node, ElementNode>,
-        context?: ElementNode[]
+        context?: Node[]
     ): CompiledQuery<ElementNode> {
         const { equals } = options;
 

--- a/src/pseudo-selectors/index.ts
+++ b/src/pseudo-selectors/index.ts
@@ -26,7 +26,7 @@ export function compilePseudoSelector<Node, ElementNode extends Node>(
     next: CompiledQuery<ElementNode>,
     selector: PseudoSelector,
     options: InternalOptions<Node, ElementNode>,
-    context: ElementNode[] | undefined,
+    context: Node[] | undefined,
     compileToken: CompileToken<Node, ElementNode>
 ): CompiledQuery<ElementNode> {
     const { name, data } = selector;

--- a/src/pseudo-selectors/subselects.ts
+++ b/src/pseudo-selectors/subselects.ts
@@ -19,7 +19,7 @@ export type Subselect = <Node, ElementNode extends Node>(
     next: CompiledQuery<ElementNode>,
     subselect: Selector[][],
     options: InternalOptions<Node, ElementNode>,
-    context: ElementNode[] | undefined,
+    context: Node[] | undefined,
     compileToken: CompileToken<Node, ElementNode>
 ) => CompiledQuery<ElementNode>;
 
@@ -76,7 +76,7 @@ export const subselects: Record<string, Subselect> = {
         next: CompiledQuery<ElementNode>,
         subselect: Selector[][],
         options: InternalOptions<Node, ElementNode>,
-        _context: ElementNode[] | undefined,
+        _context: Node[] | undefined,
         compileToken: CompileToken<Node, ElementNode>
     ): CompiledQuery<ElementNode> {
         const { adapter } = options;

--- a/src/types.ts
+++ b/src/types.ts
@@ -145,5 +145,5 @@ export type Query<ElementNode> =
 export type CompileToken<Node, ElementNode extends Node> = (
     token: InternalSelector[][],
     options: InternalOptions<Node, ElementNode>,
-    context?: ElementNode[]
+    context?: Node[]
 ) => CompiledQuery<ElementNode>;

--- a/test/api.ts
+++ b/test/api.ts
@@ -1,5 +1,5 @@
 import * as CSSselect from "../src";
-import { parseDOM } from "htmlparser2";
+import { parseDOM, parseDocument } from "htmlparser2";
 import { trueFunc, falseFunc } from "boolbase";
 import type { Element } from "domhandler";
 
@@ -67,6 +67,11 @@ describe("API", () => {
             const a = CSSselect.selectAll(".foo:has(+.bar)", dom);
             expect(a).toHaveLength(1);
             expect(a[0]).toStrictEqual(dom.children[0] as Element);
+        });
+
+        it("should accept document root nodes", () => {
+            const doc = parseDocument("<div id=foo><p>foo</p></div>");
+            expect(CSSselect.selectAll(":contains(foo)", doc)).toHaveLength(2);
         });
     });
 


### PR DESCRIPTION
This should make it possible to pass document nodes.