### PR TITLE
Update to patched version of `css-what`

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     ],
     "dependencies": {
         "boolbase": "^1.0.0",
-        "css-what": "^5.0.0",
+        "css-what": "^5.0.1",
         "domhandler": "^4.2.0",
         "domutils": "^2.6.0",
         "nth-check": "^2.0.0"


### PR DESCRIPTION
This should resolve [this](https://www.npmjs.com/advisories/1754) npm advisory, which currently flags `css-select` up.