### PR TITLE
fix: Don't add siblings multiple times in `appendNextSiblings`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -115,8 +115,9 @@ function appendNextSiblings<Node, ElementNode extends Node>(
 ): Node[] {
     // Order matters because jQuery seems to check the children before the siblings
     const elems = Array.isArray(elem) ? elem.slice(0) : [elem];
+    const elemsLength = elems.length;
 
-    for (let i = 0; i < elems.length; i++) {
+    for (let i = 0; i < elemsLength; i++) {
         const nextSiblings = getNextSiblings(elems[i], adapter);
         elems.push(...nextSiblings);
     }

--- a/test/api.ts
+++ b/test/api.ts
@@ -255,6 +255,14 @@ describe("API", () => {
             ).toStrictEqual(p);
         });
 
+        it("should not crash when siblings repeat", () => {
+            const dom = parseDOM(`<div></div>`.repeat(51)) as Element[];
+
+            expect(
+                CSSselect.selectAll("+div", dom, { context: dom })
+            ).toHaveLength(50);
+        });
+
         it("should cache results by default", () => {
             const [dom] = parseDOM(
                 '<div id="foo"><p>bar</p></div>'


### PR DESCRIPTION
This bug was hidden due to `removeSubsets` ordering elements.

Fixes #655