### PR TITLE
feat: Upgrade to css-what@6, add quirks mode option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "BSD-2-Clause",
             "dependencies": {
                 "boolbase": "^1.0.0",
-                "css-what": "^5.1.0",
+                "css-what": "^6.0.1",
                 "domhandler": "^4.3.0",
                 "domutils": "^2.8.0",
                 "nth-check": "^2.0.1"
@@ -1900,9 +1900,9 @@
             }
         },
         "node_modules/css-what": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.1.0.tgz",
-            "integrity": "sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.0.1.tgz",
+            "integrity": "sha512-z93ZGFLNc6yaoXAmVhqoSIb+BduplteCt1fepvwhBUQK6MNE4g6fgjpuZKJKp0esUe+vXWlIkwZZjNWoOKw0ZA==",
             "engines": {
                 "node": ">= 6"
             },
@@ -6984,9 +6984,9 @@
             }
         },
         "css-what": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.1.0.tgz",
-            "integrity": "sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw=="
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.0.1.tgz",
+            "integrity": "sha512-z93ZGFLNc6yaoXAmVhqoSIb+BduplteCt1fepvwhBUQK6MNE4g6fgjpuZKJKp0esUe+vXWlIkwZZjNWoOKw0ZA=="
         },
         "cssom": {
             "version": "0.4.4",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     ],
     "dependencies": {
         "boolbase": "^1.0.0",
-        "css-what": "^5.1.0",
+        "css-what": "^6.0.1",
         "domhandler": "^4.3.0",
         "domutils": "^2.8.0",
         "nth-check": "^2.0.1"

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -1,5 +1,5 @@
 import { InternalSelector } from "./types";
-import { parse, Selector } from "css-what";
+import { parse, Selector, SelectorType } from "css-what";
 import { trueFunc, falseFunc } from "boolbase";
 import sortRules from "./sort";
 import { isTraversal } from "./procedure";
@@ -31,8 +31,7 @@ export function compileUnsafe<Node, ElementNode extends Node>(
     options: InternalOptions<Node, ElementNode>,
     context?: Node[] | Node
 ): CompiledQuery<ElementNode> {
-    const token =
-        typeof selector === "string" ? parse(selector, options) : selector;
+    const token = typeof selector === "string" ? parse(selector) : selector;
     return compileToken<Node, ElementNode>(token, options, context);
 }
 
@@ -45,11 +44,15 @@ function includesScopePseudo(t: InternalSelector): boolean {
     );
 }
 
-const DESCENDANT_TOKEN: Selector = { type: "descendant" };
+const DESCENDANT_TOKEN: Selector = { type: SelectorType.Descendant };
 const FLEXIBLE_DESCENDANT_TOKEN: InternalSelector = {
     type: "_flexibleDescendant",
 };
-const SCOPE_TOKEN: Selector = { type: "pseudo", name: "scope", data: null };
+const SCOPE_TOKEN: Selector = {
+    type: SelectorType.Pseudo,
+    name: "scope",
+    data: null,
+};
 
 /*
  * CSS 4 Spec (Draft): 3.3.1. Absolutizing a Scope-relative Selector

--- a/src/procedure.ts
+++ b/src/procedure.ts
@@ -7,6 +7,7 @@ export const procedure: Record<InternalSelector["type"], number> = {
     attribute: 1,
     pseudo: 0,
     "pseudo-element": 0, // Here to make TS happy, we don't support this.
+    "column-combinator": -1,
     descendant: -1,
     child: -1,
     parent: -1,

--- a/src/pseudo-selectors/index.ts
+++ b/src/pseudo-selectors/index.ts
@@ -40,7 +40,7 @@ export function compilePseudoSelector<Node, ElementNode extends Node>(
         }
 
         // The alias has to be parsed here, to make sure options are respected.
-        const alias = parse(aliases[name], options);
+        const alias = parse(aliases[name]);
         return subselects.is(next, alias, options, context, compileToken);
     }
     if (name in filters) {

--- a/src/sort.ts
+++ b/src/sort.ts
@@ -1,5 +1,5 @@
 import type { InternalSelector } from "./types";
-import type { AttributeAction } from "css-what";
+import { AttributeAction, SelectorType } from "css-what";
 import { procedure } from "./procedure";
 
 const attributes: Record<AttributeAction, number> = {
@@ -40,7 +40,7 @@ export default function sortByProcedure(arr: InternalSelector[]): void {
 function getProcedure(token: InternalSelector): number {
     let proc = procedure[token.type];
 
-    if (token.type === "attribute") {
+    if (token.type === SelectorType.Attribute) {
         proc = attributes[token.action];
 
         if (proc === attributes.equals && token.name === "id") {
@@ -55,7 +55,7 @@ function getProcedure(token: InternalSelector): number {
              */
             proc >>= 1;
         }
-    } else if (token.type === "pseudo") {
+    } else if (token.type === SelectorType.Pseudo) {
         if (!token.data) {
             proc = 3;
         } else if (token.name === "has" || token.name === "contains") {

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,8 +100,32 @@ export interface Options<Node, ElementNode extends Node> {
      * When enabled, tag names will be case-sensitive.
      *
      * @default false
+     * @deprecated Will be infered from the document in a future version.
      */
     xmlMode?: boolean;
+    /**
+     * Lower-case attribute names.
+     *
+     * @default !xmlMode
+     * @deprecated Will be infered from the document in a future version.
+     */
+    lowerCaseAttributeNames?: boolean;
+    /**
+     * Lower-case tag names.
+     *
+     * @default !xmlMode
+     * @deprecated Will be infered from the document in a future version.
+     */
+    lowerCaseTags?: boolean;
+    /**
+     * Is the document in quirks mode?
+     *
+     * This will lead to .className and #id being case-insensitive.
+     *
+     * @default false
+     * @deprecated Will be infered from the document in a future version.
+     */
+    quirksMode?: boolean;
     /**
      * The last function in the stack, will be called with the last element
      * that's looked at.

--- a/test/api.ts
+++ b/test/api.ts
@@ -2,6 +2,7 @@ import * as CSSselect from "../src";
 import { parseDOM, parseDocument } from "htmlparser2";
 import { trueFunc, falseFunc } from "boolbase";
 import type { Element } from "domhandler";
+import { SelectorType, AttributeAction } from "css-what";
 
 const [dom] = parseDOM("<div id=foo><p>foo</p></div>") as Element[];
 const [xmlDom] = parseDOM("<DiV id=foo><P>foo</P></DiV>", {
@@ -37,8 +38,8 @@ describe("API", () => {
                 CSSselect.is(dom, [
                     [
                         {
-                            type: "attribute",
-                            action: "equals",
+                            type: SelectorType.Attribute,
+                            action: AttributeAction.Equals,
                             ignoreCase: false,
                             name: "id",
                             namespace: null,


### PR DESCRIPTION
css-what@6 dropped support for lowercasing tag & attribute names. For backwards-compatibility, these options were now added to css-select. Note that this will be removed again in a future release.

Also, introduced a new `quirksMode` option that will match .class and #ID values case-insensitively.