### PR TITLE
BREAKING: Bump dependencies, update types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
             "dependencies": {
                 "boolbase": "^1.0.0",
                 "css-what": "^6.1.0",
-                "domhandler": "^4.3.1",
-                "domutils": "^2.8.0",
+                "domhandler": "^5.0.2",
+                "domutils": "^3.0.1",
                 "nth-check": "^2.0.1"
             },
             "devDependencies": {
@@ -24,7 +24,7 @@
                 "cheerio-soupselect": "^0.1.1",
                 "eslint": "^8.13.0",
                 "eslint-config-prettier": "^8.5.0",
-                "htmlparser2": "^7.2.0",
+                "htmlparser2": "^8.0.0",
                 "jest": "^27.5.1",
                 "prettier": "^2.6.2",
                 "ts-jest": "^27.1.4",
@@ -2053,22 +2053,22 @@
             }
         },
         "node_modules/dom-serializer": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
-            "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+            "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
             "dependencies": {
-                "domelementtype": "^2.0.1",
-                "domhandler": "^4.2.0",
-                "entities": "^2.0.0"
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.2",
+                "entities": "^4.2.0"
             },
             "funding": {
                 "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
             }
         },
         "node_modules/domelementtype": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
-            "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+            "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
             "funding": [
                 {
                     "type": "github",
@@ -2098,11 +2098,11 @@
             }
         },
         "node_modules/domhandler": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-            "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.2.tgz",
+            "integrity": "sha512-pr8ToPIuwBonzUy42STpc5Cf0m69zsQ7gtCLLvKrTbhVRnRohT2pLiJmGp3PAh16nDVWpYpcRpdjuk1vFmnQUg==",
             "dependencies": {
-                "domelementtype": "^2.2.0"
+                "domelementtype": "^2.3.0"
             },
             "engines": {
                 "node": ">= 4"
@@ -2112,13 +2112,13 @@
             }
         },
         "node_modules/domutils": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-            "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+            "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
             "dependencies": {
-                "dom-serializer": "^1.0.1",
-                "domelementtype": "^2.2.0",
-                "domhandler": "^4.2.0"
+                "dom-serializer": "^2.0.0",
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.1"
             },
             "funding": {
                 "url": "https://github.com/fb55/domutils?sponsor=1"
@@ -2149,9 +2149,12 @@
             "dev": true
         },
         "node_modules/entities": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-            "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.0.tgz",
+            "integrity": "sha512-/iP1rZrSEJ0DTlPiX+jbzlA3eVkY/e8L8SozroF395fIqE3TYF/Nz7YOMAawta+vLmyJ/hkGNNPcSbMADCCXbg==",
+            "engines": {
+                "node": ">=0.12"
+            },
             "funding": {
                 "url": "https://github.com/fb55/entities?sponsor=1"
             }
@@ -2855,9 +2858,9 @@
             "dev": true
         },
         "node_modules/htmlparser2": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
-            "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.0.tgz",
+            "integrity": "sha512-4wbT2/t9kITgTLhFoPPzIh4xW/fDXE4NKQDcBhWC0fPCraSA5K26W8D09K5NAqNqsBp/f7wDN2LR2rA4GhlGhA==",
             "dev": true,
             "funding": [
                 "https://github.com/fb55/htmlparser2?sponsor=1",
@@ -2867,22 +2870,10 @@
                 }
             ],
             "dependencies": {
-                "domelementtype": "^2.0.1",
-                "domhandler": "^4.2.2",
-                "domutils": "^2.8.0",
-                "entities": "^3.0.1"
-            }
-        },
-        "node_modules/htmlparser2/node_modules/entities": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
-            "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.12"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/entities?sponsor=1"
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.2",
+                "domutils": "^3.0.1",
+                "entities": "^4.3.0"
             }
         },
         "node_modules/http-proxy-agent": {
@@ -6831,19 +6822,19 @@
             }
         },
         "dom-serializer": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
-            "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+            "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
             "requires": {
-                "domelementtype": "^2.0.1",
-                "domhandler": "^4.2.0",
-                "entities": "^2.0.0"
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.2",
+                "entities": "^4.2.0"
             }
         },
         "domelementtype": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
-            "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+            "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
         },
         "domexception": {
             "version": "2.0.1",
@@ -6863,21 +6854,21 @@
             }
         },
         "domhandler": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-            "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.2.tgz",
+            "integrity": "sha512-pr8ToPIuwBonzUy42STpc5Cf0m69zsQ7gtCLLvKrTbhVRnRohT2pLiJmGp3PAh16nDVWpYpcRpdjuk1vFmnQUg==",
             "requires": {
-                "domelementtype": "^2.2.0"
+                "domelementtype": "^2.3.0"
             }
         },
         "domutils": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-            "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+            "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
             "requires": {
-                "dom-serializer": "^1.0.1",
-                "domelementtype": "^2.2.0",
-                "domhandler": "^4.2.0"
+                "dom-serializer": "^2.0.0",
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.1"
             }
         },
         "electron-to-chromium": {
@@ -6899,9 +6890,9 @@
             "dev": true
         },
         "entities": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-            "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.0.tgz",
+            "integrity": "sha512-/iP1rZrSEJ0DTlPiX+jbzlA3eVkY/e8L8SozroF395fIqE3TYF/Nz7YOMAawta+vLmyJ/hkGNNPcSbMADCCXbg=="
         },
         "error-ex": {
             "version": "1.3.2",
@@ -7430,23 +7421,15 @@
             "dev": true
         },
         "htmlparser2": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
-            "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.0.tgz",
+            "integrity": "sha512-4wbT2/t9kITgTLhFoPPzIh4xW/fDXE4NKQDcBhWC0fPCraSA5K26W8D09K5NAqNqsBp/f7wDN2LR2rA4GhlGhA==",
             "dev": true,
             "requires": {
-                "domelementtype": "^2.0.1",
-                "domhandler": "^4.2.2",
-                "domutils": "^2.8.0",
-                "entities": "^3.0.1"
-            },
-            "dependencies": {
-                "entities": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
-                    "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
-                    "dev": true
-                }
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.2",
+                "domutils": "^3.0.1",
+                "entities": "^4.3.0"
             }
         },
         "http-proxy-agent": {

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "dependencies": {
         "boolbase": "^1.0.0",
         "css-what": "^6.1.0",
-        "domhandler": "^4.3.1",
-        "domutils": "^2.8.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
         "nth-check": "^2.0.1"
     },
     "devDependencies": {
@@ -36,7 +36,7 @@
         "cheerio-soupselect": "^0.1.1",
         "eslint": "^8.13.0",
         "eslint-config-prettier": "^8.5.0",
-        "htmlparser2": "^7.2.0",
+        "htmlparser2": "^8.0.0",
         "jest": "^27.5.1",
         "prettier": "^2.6.2",
         "ts-jest": "^27.1.4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import * as DomUtils from "domutils";
 import { falseFunc } from "boolbase";
 import type {
-    Node as DomHandlerNode,
+    AnyNode as DomHandlerNode,
     Element as DomHandlerElement,
 } from "domhandler";
 import { compile as compileRaw, compileUnsafe, compileToken } from "./compile";

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,7 +32,7 @@ export interface Adapter<Node, ElementNode extends Node> {
     /**
      * Get the parent of the node
      */
-    getParent: (node: ElementNode) => ElementNode | null;
+    getParent: (node: ElementNode) => Node | null;
 
     /**
      * Get the siblings of the node. Note that unlike jQuery's `siblings` method,

--- a/test/api.ts
+++ b/test/api.ts
@@ -2,9 +2,8 @@ import * as CSSselect from "../src";
 import { parseDOM, parseDocument } from "htmlparser2";
 import { trueFunc, falseFunc } from "boolbase";
 import * as DomUtils from "domutils";
-import type { Node, Element } from "domhandler";
+import type { Element } from "domhandler";
 import { SelectorType, AttributeAction } from "css-what";
-import { Adapter } from "../src/types";
 
 const [dom] = parseDOM("<div id=foo><p>foo</p></div>") as Element[];
 const [xmlDom] = parseDOM("<DiV id=foo><P>foo</P></DiV>", {
@@ -71,7 +70,7 @@ describe("API", () => {
             ) as Element[];
             const a = CSSselect.selectAll(".foo:has(+.bar)", dom);
             expect(a).toHaveLength(1);
-            expect(a[0]).toStrictEqual(dom.children[0] as Element);
+            expect(a[0]).toStrictEqual(dom.children[0]);
         });
 
         it("should accept document root nodes", () => {
@@ -317,7 +316,7 @@ describe("API", () => {
 
     describe("optional adapter methods", () => {
         it("should support prevElementSibling", () => {
-            const adapter: Adapter<Node, Element> = {
+            const adapter = {
                 ...DomUtils,
                 prevElementSibling: undefined,
             };
@@ -334,9 +333,9 @@ describe("API", () => {
         it("should support isHovered", () => {
             const dom = parseDOM(`${"<p>foo".repeat(10)}`) as Element[];
 
-            const adapter: Adapter<Node, Element> = {
+            const adapter = {
                 ...DomUtils,
-                isHovered: (el) => el === dom[dom.length - 1],
+                isHovered: (el: Element) => el === dom[dom.length - 1],
             };
 
             const selection = CSSselect.selectAll("p:hover", dom, { adapter });

--- a/test/icontains.ts
+++ b/test/icontains.ts
@@ -14,43 +14,31 @@ describe("icontains", () => {
                 dom
             );
             expect(matches).toHaveLength(2);
-            expect(matches).toStrictEqual([
-                dom[0],
-                dom[0].children[1],
-            ] as Element[]);
+            expect(matches).toStrictEqual([dom[0], dom[0].children[1]]);
             matches = CSSselect.selectAll(
                 ":icontains(inDeeD-THAT's a DELICATE matteR.)",
                 dom
             );
             expect(matches).toHaveLength(2);
-            expect(matches).toStrictEqual([
-                dom[0],
-                dom[0].children[1],
-            ] as Element[]);
+            expect(matches).toStrictEqual([dom[0], dom[0].children[1]]);
         });
 
         it("should match substring", () => {
             let matches = CSSselect.selectAll(":icontains(indeed)", dom);
             expect(matches).toHaveLength(2);
-            expect(matches).toStrictEqual([
-                dom[0],
-                dom[0].children[1],
-            ] as Element[]);
+            expect(matches).toStrictEqual([dom[0], dom[0].children[1]]);
             matches = CSSselect.selectAll(":icontains(inDeeD)", dom);
             expect(matches).toHaveLength(2);
-            expect(matches).toStrictEqual([
-                dom[0],
-                dom[0].children[1],
-            ] as Element[]);
+            expect(matches).toStrictEqual([dom[0], dom[0].children[1]]);
         });
 
         it("should match specific element", () => {
             let matches = CSSselect.selectAll("p:icontains(matter)", dom);
             expect(matches).toHaveLength(1);
-            expect(matches).toStrictEqual([dom[0].children[0] as Element]);
+            expect(matches).toStrictEqual([dom[0].children[0]]);
             matches = CSSselect.selectAll("p:icontains(mATter)", dom);
             expect(matches).toHaveLength(1);
-            expect(matches).toStrictEqual([dom[0].children[0] as Element]);
+            expect(matches).toStrictEqual([dom[0].children[0]]);
         });
 
         it("should match multiple elements", () => {
@@ -60,14 +48,14 @@ describe("icontains", () => {
                 dom[0],
                 dom[0].children[0],
                 dom[0].children[1],
-            ] as Element[]);
+            ]);
             matches = CSSselect.selectAll(":icontains(mATter)", dom);
             expect(matches).toHaveLength(3);
             expect(matches).toStrictEqual([
                 dom[0],
                 dom[0].children[0],
                 dom[0].children[1],
-            ] as Element[]);
+            ]);
         });
 
         it("should match empty string", () => {
@@ -77,7 +65,7 @@ describe("icontains", () => {
                 dom[0],
                 dom[0].children[0],
                 dom[0].children[1],
-            ] as Element[]);
+            ]);
         });
 
         it("should match quoted string", () => {
@@ -87,13 +75,13 @@ describe("icontains", () => {
                 dom[0],
                 dom[0].children[0],
                 dom[0].children[1],
-            ] as Element[]);
+            ]);
             matches = CSSselect.selectAll("p:icontains('matter')", dom);
             expect(matches).toHaveLength(1);
-            expect(matches).toStrictEqual([dom[0].children[0] as Element]);
+            expect(matches).toStrictEqual([dom[0].children[0]]);
             matches = CSSselect.selectAll('p:icontains("matter")', dom);
             expect(matches).toHaveLength(1);
-            expect(matches).toStrictEqual([dom[0].children[0] as Element]);
+            expect(matches).toStrictEqual([dom[0].children[0]]);
         });
 
         it("should match whitespace", () => {
@@ -103,14 +91,14 @@ describe("icontains", () => {
                 dom[0],
                 dom[0].children[0],
                 dom[0].children[1],
-            ] as Element[]);
+            ]);
             matches = CSSselect.selectAll(":icontains( mATter)", dom);
             expect(matches).toHaveLength(3);
             expect(matches).toStrictEqual([
                 dom[0],
                 dom[0].children[0],
                 dom[0].children[1],
-            ] as Element[]);
+            ]);
         });
     });
 

--- a/test/nwmatcher.ts
+++ b/test/nwmatcher.ts
@@ -19,9 +19,7 @@ function getByIds(...args: string[]): Element[] {
 }
 
 function getById(id: string): Element {
-    const elem = DomUtils.getElementById(id, document);
-    if (!elem) throw new Error(`Did not find element with ID ${id}`);
-    return elem;
+    return document.getElementById(id);
 }
 
 // NWMatcher methods

--- a/test/qwery.ts
+++ b/test/qwery.ts
@@ -2,7 +2,7 @@ import * as helper from "./tools/helper";
 const document = helper.getDocument("qwery.html");
 import * as CSSselect from "../src";
 import * as DomUtils from "domutils";
-import type { Element } from "domhandler";
+import { AnyNode, Element, ParentNode } from "domhandler";
 import { parseDOM } from "htmlparser2";
 
 const location = { hash: "" };
@@ -39,14 +39,12 @@ const doc = parseDOM(
         '<div id="lonelyHsoob"></div></root>'
 );
 
-const el = DomUtils.getElementById("attr-child-boosh", document);
-
-if (!el) throw new Error("Couldn't find element");
+const el = document.getElementById("attr-child-boosh");
 
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-const pseudos = DomUtils.getElementById("pseudos", document)!.children.filter(
-    DomUtils.isTag
-);
+const pseudos = document
+    .getElementById("pseudos")
+    .children.filter(DomUtils.isTag);
 
 describe("qwery", () => {
     describe("Contexts", () => {
@@ -233,7 +231,7 @@ describe("qwery", () => {
     describe("CSS 2", () => {
         it("get elements by attribute", () => {
             const wanted = CSSselect.selectAll("#boosh div[test]", document)[0];
-            const expected = DomUtils.getElementById("booshTest", document);
+            const expected = document.getElementById("booshTest");
             expect(wanted).toBe(expected); // Found attribute
             expect(
                 CSSselect.selectAll("#boosh div[test=fg]", document)[0]
@@ -253,7 +251,7 @@ describe("qwery", () => {
         });
 
         it("crazy town", () => {
-            const el = DomUtils.getElementById("attr-test3", document);
+            const el = document.getElementById("attr-test3");
             expect(
                 CSSselect.selectAll(
                     'div#attr-test3.found.you[title="whatup duders"]',
@@ -267,14 +265,14 @@ describe("qwery", () => {
         /* CSS 2 SPEC */
 
         it("[attr]", () => {
-            const expected = DomUtils.getElementById("attr-test-1", document);
+            const expected = document.getElementById("attr-test-1");
             expect(
                 CSSselect.selectAll("#attributes div[unique-test]", document)[0]
             ).toBe(expected); // Found attribute with [attr]
         });
 
         it("[attr=val]", () => {
-            const expected = DomUtils.getElementById("attr-test-2", document);
+            const expected = document.getElementById("attr-test-2");
             expect(
                 CSSselect.selectAll(
                     '#attributes div[test="two-foo"]',
@@ -296,14 +294,14 @@ describe("qwery", () => {
         });
 
         it("[attr~=val]", () => {
-            const expected = DomUtils.getElementById("attr-test-3", document);
+            const expected = document.getElementById("attr-test-3");
             expect(
                 CSSselect.selectAll("#attributes div[test~=three]", document)[0]
             ).toBe(expected); // Found attribute with ~=
         });
 
         it("[attr|=val]", () => {
-            const expected = DomUtils.getElementById("attr-test-2", document);
+            const expected = document.getElementById("attr-test-2");
             expect(
                 CSSselect.selectAll(
                     '#attributes div[test|="two-foo"]',
@@ -316,7 +314,7 @@ describe("qwery", () => {
         });
 
         it("[href=#x] special case", () => {
-            const expected = DomUtils.getElementById("attr-test-4", document);
+            const expected = document.getElementById("attr-test-4");
             expect(
                 CSSselect.selectAll('#attributes a[href="#aname"]', document)[0]
             ).toBe(expected); // Found attribute with href=#x
@@ -325,21 +323,21 @@ describe("qwery", () => {
         /* CSS 3 SPEC */
 
         it("[attr^=val]", () => {
-            const expected = DomUtils.getElementById("attr-test-2", document);
+            const expected = document.getElementById("attr-test-2");
             expect(
                 CSSselect.selectAll("#attributes div[test^=two]", document)[0]
             ).toBe(expected); // Found attribute with ^=
         });
 
         it("[attr$=val]", () => {
-            const expected = DomUtils.getElementById("attr-test-2", document);
+            const expected = document.getElementById("attr-test-2");
             expect(
                 CSSselect.selectAll("#attributes div[test$=foo]", document)[0]
             ).toBe(expected); // Found attribute with $=
         });
 
         it("[attr*=val]", () => {
-            const expected = DomUtils.getElementById("attr-test-3", document);
+            const expected = document.getElementById("attr-test-3");
             expect(
                 CSSselect.selectAll("#attributes div[test*=hree]", document)[0]
             ).toBe(expected); // Found attribute with *=
@@ -500,28 +498,28 @@ describe("qwery", () => {
         it("should not get weird tokens", () => {
             expect(
                 CSSselect.selectAll('div .tokens[title="one"]', document)[0]
-            ).toBe(DomUtils.getElementById("token-one", document)); // Found div .tokens[title="one"]
+            ).toBe(document.getElementById("token-one")); // Found div .tokens[title="one"]
             expect(
                 CSSselect.selectAll('div .tokens[title="one two"]', document)[0]
-            ).toBe(DomUtils.getElementById("token-two", document)); // Found div .tokens[title="one two"]
+            ).toBe(document.getElementById("token-two")); // Found div .tokens[title="one two"]
             expect(
                 CSSselect.selectAll(
                     'div .tokens[title="one two three #%"]',
                     document
                 )[0]
-            ).toBe(DomUtils.getElementById("token-three", document)); // Found div .tokens[title="one two three #%"]
+            ).toBe(document.getElementById("token-three")); // Found div .tokens[title="one two three #%"]
             expect(
                 CSSselect.selectAll(
                     "div .tokens[title='one two three #%'] a",
                     document
                 )[0]
-            ).toBe(DomUtils.getElementById("token-four", document)); // Found div .tokens[title=\'one two three #%\'] a
+            ).toBe(document.getElementById("token-four")); // Found div .tokens[title=\'one two three #%\'] a
             expect(
                 CSSselect.selectAll(
                     'div .tokens[title="one two three #%"] a[href$=foo] div',
                     document
                 )[0]
-            ).toBe(DomUtils.getElementById("token-five", document)); // Found div .tokens[title="one two three #%"] a[href=foo] div
+            ).toBe(document.getElementById("token-five")); // Found div .tokens[title="one two three #%"] a[href=foo] div
         });
     });
 
@@ -548,7 +546,7 @@ describe("qwery", () => {
             function tag(el: Element) {
                 return el.name.toLowerCase();
             }
-            const els = CSSselect.selectAll(
+            const els = CSSselect.selectAll<AnyNode, ParentNode>(
                 "#order-matters .order-matters",
                 document
             ) as Element[];
@@ -602,10 +600,7 @@ describe("qwery", () => {
         });
 
         it('ol > li[attr="boosh"]:last-child', () => {
-            const expected = DomUtils.getElementById(
-                "attr-child-boosh",
-                document
-            );
+            const expected = document.getElementById("attr-child-boosh");
             expect(
                 CSSselect.selectAll(
                     'ol > li[attr="boosh"]:last-child',
@@ -863,18 +858,18 @@ describe("qwery", () => {
         it("context", () => {
             expect(
                 CSSselect.is(el, "li#attr-child-boosh[attr=boosh]", {
-                    context: CSSselect.selectAll(
+                    context: CSSselect.selectAll<AnyNode, ParentNode>(
                         "#list",
                         document
-                    )[0] as Element,
+                    )[0],
                 })
             ).toBeTruthy(); // Context
             expect(
                 CSSselect.is(el, "ol#list li#attr-child-boosh[attr=boosh]", {
-                    context: CSSselect.selectAll(
+                    context: CSSselect.selectAll<AnyNode, ParentNode>(
                         "#boosh",
                         document
-                    )[0] as Element,
+                    )[0],
                 })
             ).toBeFalsy(); // Wrong context
         });

--- a/test/tools/sizzle-testinit.ts
+++ b/test/tools/sizzle-testinit.ts
@@ -1,6 +1,6 @@
 import * as helper from "./helper";
 import CSSselect from "../../src";
-import type { Element, Node } from "domhandler";
+import type { Element, Node, Document } from "domhandler";
 let document = loadDoc();
 
 export function loadDoc(): helper.SimpleDocument {
@@ -36,10 +36,10 @@ export function t(
     expect(actualIds).toStrictEqual(expectedIds);
 }
 
-const xmlDoc = helper.getDOMFromPath("fries.xml", {
+const xmlDoc = helper.getDocumentFromPath("fries.xml", {
     xmlMode: true,
 });
 
-export function createWithFriesXML(): Node[] {
+export function createWithFriesXML(): Document {
     return xmlDoc;
 }


### PR DESCRIPTION
BREAKING: We will now filter for `isTag` whenever we look for a parent. This will prevent issues where we try to check a `Document` object for non-existent keys.