### PR TITLE
fix: Throw an error for `:host-context`

### DIFF
--- a/src/pseudo-selectors/index.ts
+++ b/src/pseudo-selectors/index.ts
@@ -32,6 +32,10 @@ export function compilePseudoSelector<Node, ElementNode extends Node>(
     const { name, data } = selector;
 
     if (Array.isArray(data)) {
+        if (!(name in subselects)) {
+            throw new Error(`Unknown pseudo-class :${name}(${data})`);
+        }
+
         return subselects[name](next, data, options, context, compileToken);
     }
     if (name in aliases) {
@@ -56,5 +60,5 @@ export function compilePseudoSelector<Node, ElementNode extends Node>(
             ? (elem) => pseudo(elem, options, data)
             : (elem) => pseudo(elem, options, data) && next(elem);
     }
-    throw new Error(`unmatched pseudo-class :${name}`);
+    throw new Error(`Unknown pseudo-class :${name}`);
 }

--- a/test/api.ts
+++ b/test/api.ts
@@ -342,5 +342,10 @@ describe("API", () => {
             expect(selection).toHaveLength(1);
             expect(selection[0]).toBe(dom[dom.length - 1]);
         });
+
+        it("should not match any elements if `isHovered` is not defined", () => {
+            const dom = parseDOM(`${"<p>foo".repeat(10)}`);
+            expect(CSSselect.selectAll("p:hover", dom)).toHaveLength(0);
+        });
     });
 });

--- a/test/nwmatcher.ts
+++ b/test/nwmatcher.ts
@@ -27,6 +27,11 @@ const select = (query: string, doc: Node[] | Node = document): Node[] =>
     CSSselect.selectAll(query, doc);
 
 describe("NWMatcher", () => {
+    // Test whether our helper above throws
+    it("should throw when getting an element by an invalid ID", () => {
+        expect(() => getById("foo")).toThrow();
+    });
+
     describe("Basic Selectors", () => {
         it("*", () => {
             // Universal selector

--- a/test/pseudo-classes.ts
+++ b/test/pseudo-classes.ts
@@ -1,12 +1,12 @@
 import * as CSSselect from "../src";
-import { parseDOM } from "htmlparser2";
-import type { Element } from "domhandler";
+import { DomUtils, parseDOM } from "htmlparser2";
+import { Element } from "domhandler";
 
 const dom = parseDOM(
     "<div><p>In the end, it doesn't really Matter.</p><div>Indeed-that's a delicate matter.</div>"
 ) as Element[];
 
-describe("icontains", () => {
+describe(":icontains", () => {
     describe("ignore case", () => {
         it("should match full string", () => {
             let matches = CSSselect.selectAll(
@@ -107,5 +107,40 @@ describe("icontains", () => {
             const matches = CSSselect.selectAll("p:icontains(indeed)", dom);
             expect(matches).toHaveLength(0);
         });
+    });
+});
+
+describe("unmatched", () => {
+    it("should throw on unknown pseudo-class (#741)", () => {
+        expect(() => CSSselect.selectAll(":unmatched(foo)", dom)).toThrow(
+            "Unknown pseudo-class :unmatched"
+        );
+
+        expect(() => CSSselect.selectAll(":unmatched(foo)", dom)).toThrow(
+            "Unknown pseudo-class :unmatched"
+        );
+
+        expect(() => CSSselect.selectAll(":host-context(foo)", dom)).toThrow(
+            "Unknown pseudo-class :host-context"
+        );
+    });
+});
+
+describe(":first-child", () => {
+    it("should match", () => {
+        const matches = CSSselect.selectAll(":first-child", dom);
+        expect(matches).toHaveLength(2);
+        expect(matches).toStrictEqual([dom[0], dom[0].children[0]]);
+    });
+
+    it("should work without `prevElementSibling`", () => {
+        const adapter = {
+            ...DomUtils,
+            prevElementSibling: undefined,
+        };
+
+        const matches = CSSselect.selectAll(":first-child", dom, { adapter });
+        expect(matches).toHaveLength(2);
+        expect(matches).toStrictEqual([dom[0], dom[0].children[0]]);
     });
 });


### PR DESCRIPTION
Fixes #741

BREAKING: The error message for unknown pseudo classes has changed.

Also adds several tests, mostly for pseudo-classes.