### PR TITLE
feat: Add `pseudos` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ All options are optional.
     sometimes greatly improving querying performance. Disable this if your
     document can change in between queries with the same compiled selector.
     Default: `true`.
+-   `pseudos`: A map of pseudo-selectors to functions or strings.
 
 #### Custom Adapters
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -198,4 +198,5 @@ export function is<Node, ElementNode extends Node>(
 export default selectAll;
 
 // Export filters, pseudos and aliases to allow users to supply their own.
+/** @deprecated Use the `pseudos` option instead. */
 export { filters, pseudos, aliases } from "./pseudo-selectors/index.js";

--- a/src/pseudo-selectors/pseudos.ts
+++ b/src/pseudo-selectors/pseudos.ts
@@ -4,7 +4,7 @@ import type { InternalOptions } from "../types.js";
 export type Pseudo = <Node, ElementNode extends Node>(
     elem: ElementNode,
     options: InternalOptions<Node, ElementNode>,
-    subselect?: ElementNode | string | null
+    subselect?: string | null
 ) => boolean;
 
 // While filters are precompiled, pseudos get called when they are needed
@@ -92,16 +92,17 @@ export const pseudos: Record<string, Pseudo> = {
     },
 };
 
-export function verifyPseudoArgs(
-    func: Pseudo,
+export function verifyPseudoArgs<T extends Array<unknown>>(
+    func: (...args: T) => boolean,
     name: string,
-    subselect: PseudoSelector["data"]
+    subselect: PseudoSelector["data"],
+    argIndex: number
 ): void {
     if (subselect === null) {
-        if (func.length > 2) {
-            throw new Error(`pseudo-selector :${name} requires an argument`);
+        if (func.length > argIndex) {
+            throw new Error(`Pseudo-class :${name} requires an argument`);
         }
-    } else if (func.length === 2) {
-        throw new Error(`pseudo-selector :${name} doesn't have any arguments`);
+    } else if (func.length === argIndex) {
+        throw new Error(`Pseudo-class :${name} doesn't have any arguments`);
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -128,6 +128,18 @@ export interface Options<Node, ElementNode extends Node> {
      */
     quirksMode?: boolean;
     /**
+     * Pseudo-classes that override the default ones.
+     *
+     * Maps from names to either strings of functions.
+     * - A string value is a selector that the element must match to be selected.
+     * - A function is called with the element as its first argument, and optional
+     *  parameters second. If it returns true, the element is selected.
+     */
+    pseudos?: Record<
+        string,
+        string | ((elem: ElementNode, value?: string | null) => boolean)
+    >;
+    /**
      * The last function in the stack, will be called with the last element
      * that's looked at.
      */

--- a/test/api.ts
+++ b/test/api.ts
@@ -127,6 +127,24 @@ describe("API", () => {
 
             delete CSSselect.pseudos["foovalue"];
         });
+
+        it("should throw if parameter is supplied for user-provided pseudo", () =>
+            expect(() =>
+                CSSselect.compile(":foovalue(boo)", {
+                    pseudos: { foovalue: "tag" },
+                })
+            ).toThrow("doesn't have any arguments"));
+
+        it("should throw if no parameter is supplied for user-provided pseudo", () =>
+            expect(() =>
+                CSSselect.compile(":foovalue", {
+                    pseudos: {
+                        foovalue(_el, data) {
+                            return data != null;
+                        },
+                    },
+                })
+            ).toThrow("requires an argument"));
     });
 
     describe("unsatisfiable and universally valid selectors", () => {

--- a/test/qwery.ts
+++ b/test/qwery.ts
@@ -2,21 +2,27 @@ import * as helper from "./tools/helper";
 const document = helper.getDocument("qwery.html");
 import * as CSSselect from "../src";
 import * as DomUtils from "domutils";
-import type { AnyNode, Element, ParentNode } from "domhandler";
+import type { AnyNode, Element } from "domhandler";
 import { parseDOM } from "htmlparser2";
 
 const location = { hash: "" };
-CSSselect.pseudos["target"] = (elem, { adapter }) =>
-    adapter.getAttributeValue(elem, "id") === location.hash.substr(1);
+const options = {
+    pseudos: {
+        target: (elem: Element) =>
+            DomUtils.getAttributeValue(elem, "id") === location.hash.substr(1),
+        humanoid: ":matches(li,ol):contains(human)",
+    },
+};
+
+function selectAll(selector: string, context: AnyNode | AnyNode[] = document) {
+    return CSSselect.selectAll<AnyNode, Element>(selector, context, options);
+}
 
 // ---
 
 /*
  * Adapted from https://github.com/ded/qwery/blob/master/tests/tests.js
  */
-
-CSSselect.pseudos["humanoid"] = (e) =>
-    CSSselect.is(e, ":matches(li,ol):contains(human)");
 
 const frag = parseDOM(
     '<root><div class="d i v">' +
@@ -41,7 +47,6 @@ const doc = parseDOM(
 
 const el = document.getElementById("attr-child-boosh");
 
-// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const pseudos = document
     .getElementById("pseudos")
     .children.filter(DomUtils.isTag);
@@ -49,142 +54,78 @@ const pseudos = document
 describe("qwery", () => {
     describe("Contexts", () => {
         it("should be able to pass optional context", () => {
-            expect(CSSselect.selectAll(".a", document)).toHaveLength(3); // No context found 3 elements (.a)
-            expect(
-                CSSselect.selectAll(
-                    ".a",
-                    CSSselect.selectAll("#boosh", document)
-                )
-            ).toHaveLength(2); // Context found 2 elements (#boosh .a)
+            expect(selectAll(".a")).toHaveLength(3); // No context found 3 elements (.a)
+            expect(selectAll(".a", selectAll("#boosh"))).toHaveLength(2); // Context found 2 elements (#boosh .a)
         });
 
         it("should be able to pass qwery result as context", () => {
-            expect(
-                CSSselect.selectAll(
-                    ".a",
-                    CSSselect.selectAll("#boosh", document)
-                )
-            ).toHaveLength(2); // Context found 2 elements(.a, #boosh)
-            expect(
-                CSSselect.selectAll("> .a", CSSselect.selectAll(".a", document))
-            ).toHaveLength(1); // Context found 0 elements(.a, .a)
-            expect(
-                CSSselect.selectAll("> .a", CSSselect.selectAll(".b", document))
-            ).toHaveLength(1); // Context found 1 elements(.a, .b)
-            expect(
-                CSSselect.selectAll(
-                    "> .a",
-                    CSSselect.selectAll("#boosh .b", document)
-                )
-            ).toHaveLength(1); // Context found 1 elements(.a, #boosh .b)
-            expect(
-                CSSselect.selectAll(
-                    "> .b",
-                    CSSselect.selectAll("#boosh .b", document)
-                )
-            ).toHaveLength(0); // Context found 0 elements(.b, #boosh .b)
+            expect(selectAll(".a", selectAll("#boosh"))).toHaveLength(2); // Context found 2 elements(.a, #boosh)
+            expect(selectAll("> .a", selectAll(".a"))).toHaveLength(1); // Context found 0 elements(.a, .a)
+            expect(selectAll("> .a", selectAll(".b"))).toHaveLength(1); // Context found 1 elements(.a, .b)
+            expect(selectAll("> .a", selectAll("#boosh .b"))).toHaveLength(1); // Context found 1 elements(.a, #boosh .b)
+            expect(selectAll("> .b", selectAll("#boosh .b"))).toHaveLength(0); // Context found 0 elements(.b, #boosh .b)
         });
 
         it("should not return duplicates from combinators", () => {
-            expect(CSSselect.selectAll("#boosh,#boosh", document)).toHaveLength(
-                1
-            ); // Two booshes dont make a thing go right
-            expect(
-                CSSselect.selectAll("#boosh,.apples,#boosh", document)
-            ).toHaveLength(1); // Two booshes and an apple dont make a thing go right
+            expect(selectAll("#boosh,#boosh")).toHaveLength(1); // Two booshes dont make a thing go right
+            expect(selectAll("#boosh,.apples,#boosh")).toHaveLength(1); // Two booshes and an apple dont make a thing go right
         });
 
         it("byId sub-queries within context", () => {
+            expect(selectAll("#booshTest", selectAll("#boosh"))).toHaveLength(
+                1
+            ); // Found "#id #id"
             expect(
-                CSSselect.selectAll(
-                    "#booshTest",
-                    CSSselect.selectAll("#boosh", document)
-                )
-            ).toHaveLength(1); // Found "#id #id"
-            expect(
-                CSSselect.selectAll(
-                    ".a.b #booshTest",
-                    CSSselect.selectAll("#boosh", document)
-                )
+                selectAll(".a.b #booshTest", selectAll("#boosh"))
             ).toHaveLength(1); // Found ".class.class #id"
             expect(
-                CSSselect.selectAll(
-                    ".a>#booshTest",
-                    CSSselect.selectAll("#boosh", document)
-                )
+                selectAll(".a>#booshTest", selectAll("#boosh"))
             ).toHaveLength(1); // Found ".class>#id"
             expect(
-                CSSselect.selectAll(
-                    ">.a>#booshTest",
-                    CSSselect.selectAll("#boosh", document)
-                )
+                selectAll(">.a>#booshTest", selectAll("#boosh"))
             ).toHaveLength(1); // Found ">.class>#id"
-            expect(
-                CSSselect.selectAll(
-                    "#boosh",
-                    CSSselect.selectAll("#booshTest", document)
-                )
-            ).toHaveLength(0); // Shouldn't find #boosh (ancestor) within #booshTest (descendent)
-            expect(
-                CSSselect.selectAll(
-                    "#boosh",
-                    CSSselect.selectAll("#lonelyBoosh", document)
-                )
-            ).toHaveLength(0); // Shouldn't find #boosh within #lonelyBoosh (unrelated)
+            expect(selectAll("#boosh", selectAll("#booshTest"))).toHaveLength(
+                0
+            ); // Shouldn't find #boosh (ancestor) within #booshTest (descendent)
+            expect(selectAll("#boosh", selectAll("#lonelyBoosh"))).toHaveLength(
+                0
+            ); // Shouldn't find #boosh within #lonelyBoosh (unrelated)
         });
     });
 
     describe("CSS 1", () => {
         it("get element by id", () => {
-            const result = CSSselect.selectAll("#boosh", document);
+            const result = selectAll("#boosh");
             expect(result[0]).toBeTruthy(); // Found element with id=boosh
-            expect(CSSselect.selectAll("h1", document)[0]).toBeTruthy(); // Found 1 h1
+            expect(selectAll("h1")[0]).toBeTruthy(); // Found 1 h1
         });
 
         it("byId sub-queries", () => {
-            expect(
-                CSSselect.selectAll("#boosh #booshTest", document)
-            ).toHaveLength(1); // Found "#id #id"
-            expect(
-                CSSselect.selectAll(".a.b #booshTest", document)
-            ).toHaveLength(1); // Found ".class.class #id"
-            expect(
-                CSSselect.selectAll("#boosh>.a>#booshTest", document)
-            ).toHaveLength(1); // Found "#id>.class>#id"
-            expect(CSSselect.selectAll(".a>#booshTest", document)).toHaveLength(
-                1
-            ); // Found ".class>#id"
+            expect(selectAll("#boosh #booshTest")).toHaveLength(1); // Found "#id #id"
+            expect(selectAll(".a.b #booshTest")).toHaveLength(1); // Found ".class.class #id"
+            expect(selectAll("#boosh>.a>#booshTest")).toHaveLength(1); // Found "#id>.class>#id"
+            expect(selectAll(".a>#booshTest")).toHaveLength(1); // Found ".class>#id"
         });
 
         it("get elements by class", () => {
-            expect(CSSselect.selectAll("#boosh .a", document)).toHaveLength(2); // Found two elements
-            expect(
-                CSSselect.selectAll("#boosh div.a", document)[0]
-            ).toBeTruthy(); // Found one element
-            expect(CSSselect.selectAll("#boosh div", document)).toHaveLength(2); // Found two {div} elements
-            expect(
-                CSSselect.selectAll("#boosh span", document)[0]
-            ).toBeTruthy(); // Found one {span} element
-            expect(
-                CSSselect.selectAll("#boosh div div", document)[0]
-            ).toBeTruthy(); // Found a single div
-            expect(CSSselect.selectAll("a.odd", document)).toHaveLength(1); // Found single a
+            expect(selectAll("#boosh .a")).toHaveLength(2); // Found two elements
+            expect(selectAll("#boosh div.a")[0]).toBeTruthy(); // Found one element
+            expect(selectAll("#boosh div")).toHaveLength(2); // Found two {div} elements
+            expect(selectAll("#boosh span")[0]).toBeTruthy(); // Found one {span} element
+            expect(selectAll("#boosh div div")[0]).toBeTruthy(); // Found a single div
+            expect(selectAll("a.odd")).toHaveLength(1); // Found single a
         });
 
         it("combos", () => {
-            expect(
-                CSSselect.selectAll("#boosh div,#boosh span", document)
-            ).toHaveLength(3); // Found 2 divs and 1 span
+            expect(selectAll("#boosh div,#boosh span")).toHaveLength(3); // Found 2 divs and 1 span
         });
 
         it("class with dashes", () => {
-            expect(
-                CSSselect.selectAll(".class-with-dashes", document)
-            ).toHaveLength(1); // Found something
+            expect(selectAll(".class-with-dashes")).toHaveLength(1); // Found something
         });
 
         it("should ignore comment nodes", () => {
-            expect(CSSselect.selectAll("#boosh *", document)).toHaveLength(4); // Found only 4 elements under #boosh
+            expect(selectAll("#boosh *")).toHaveLength(4); // Found only 4 elements under #boosh
         });
 
         it("deep messy relationships", () => {
@@ -195,34 +136,20 @@ describe("qwery", () => {
              * they are useful for making sure the dom crawler doesn't stop short or over-extend as it works
              * up the tree the crawl needs to be comprehensive
              */
+            expect(selectAll("div#fixtures > div a")).toHaveLength(5); // Found four results for "div#fixtures > div a"
             expect(
-                CSSselect.selectAll("div#fixtures > div a", document)
-            ).toHaveLength(5); // Found four results for "div#fixtures > div a"
-            expect(
-                CSSselect.selectAll(
-                    ".direct-descend > .direct-descend .lvl2",
-                    document
-                )
+                selectAll(".direct-descend > .direct-descend .lvl2")
             ).toHaveLength(1); // Found one result for ".direct-descend > .direct-descend .lvl2"
             expect(
-                CSSselect.selectAll(
-                    ".direct-descend > .direct-descend div",
-                    document
-                )
+                selectAll(".direct-descend > .direct-descend div")
             ).toHaveLength(1); // Found one result for ".direct-descend > .direct-descend div"
             expect(
-                CSSselect.selectAll(
-                    ".direct-descend > .direct-descend div",
-                    document
-                )
+                selectAll(".direct-descend > .direct-descend div")
             ).toHaveLength(1); // Found one result for ".direct-descend > .direct-descend div"
+            expect(selectAll("div#fixtures div ~ a div")).toHaveLength(0); // Found no results for odd query
             expect(
-                CSSselect.selectAll("div#fixtures div ~ a div", document)
-            ).toHaveLength(0); // Found no results for odd query
-            expect(
-                CSSselect.selectAll(
-                    ".direct-descend > .direct-descend > .direct-descend ~ .lvl2",
-                    document
+                selectAll(
+                    ".direct-descend > .direct-descend > .direct-descend ~ .lvl2"
                 )
             ).toHaveLength(0); // Found no results for another odd query
         });
@@ -230,33 +157,22 @@ describe("qwery", () => {
 
     describe("CSS 2", () => {
         it("get elements by attribute", () => {
-            const wanted = CSSselect.selectAll("#boosh div[test]", document)[0];
+            const wanted = selectAll("#boosh div[test]")[0];
             const expected = document.getElementById("booshTest");
             expect(wanted).toBe(expected); // Found attribute
-            expect(
-                CSSselect.selectAll("#boosh div[test=fg]", document)[0]
-            ).toBe(expected); // Found attribute with value
-            expect(
-                CSSselect.selectAll('em[rel~="copyright"]', document)
-            ).toHaveLength(1); // Found em[rel~="copyright"]
-            expect(
-                CSSselect.selectAll('em[nopass~="copyright"]', document)
-            ).toHaveLength(0); // Found em[nopass~="copyright"]
+            expect(selectAll("#boosh div[test=fg]")[0]).toBe(expected); // Found attribute with value
+            expect(selectAll('em[rel~="copyright"]')).toHaveLength(1); // Found em[rel~="copyright"]
+            expect(selectAll('em[nopass~="copyright"]')).toHaveLength(0); // Found em[nopass~="copyright"]
         });
 
         it("should not throw error by attribute selector", () => {
-            expect(CSSselect.selectAll('[foo^="bar"]', document)).toHaveLength(
-                1
-            ); // Found 1 element
+            expect(selectAll('[foo^="bar"]')).toHaveLength(1); // Found 1 element
         });
 
         it("crazy town", () => {
             const el = document.getElementById("attr-test3");
             expect(
-                CSSselect.selectAll(
-                    'div#attr-test3.found.you[title="whatup duders"]',
-                    document
-                )[0]
+                selectAll('div#attr-test3.found.you[title="whatup duders"]')[0]
             ).toBe(el); // Found the right element
         });
     });
@@ -266,258 +182,159 @@ describe("qwery", () => {
 
         it("[attr]", () => {
             const expected = document.getElementById("attr-test-1");
-            expect(
-                CSSselect.selectAll("#attributes div[unique-test]", document)[0]
-            ).toBe(expected); // Found attribute with [attr]
+            expect(selectAll("#attributes div[unique-test]")[0]).toBe(expected); // Found attribute with [attr]
         });
 
         it("[attr=val]", () => {
             const expected = document.getElementById("attr-test-2");
-            expect(
-                CSSselect.selectAll(
-                    '#attributes div[test="two-foo"]',
-                    document
-                )[0]
-            ).toBe(expected); // Found attribute with =
-            expect(
-                CSSselect.selectAll(
-                    "#attributes div[test='two-foo']",
-                    document
-                )[0]
-            ).toBe(expected); // Found attribute with =
-            expect(
-                CSSselect.selectAll(
-                    "#attributes div[test=two-foo]",
-                    document
-                )[0]
-            ).toBe(expected); // Found attribute with =
+            expect(selectAll('#attributes div[test="two-foo"]')[0]).toBe(
+                expected
+            ); // Found attribute with =
+            expect(selectAll("#attributes div[test='two-foo']")[0]).toBe(
+                expected
+            ); // Found attribute with =
+            expect(selectAll("#attributes div[test=two-foo]")[0]).toBe(
+                expected
+            ); // Found attribute with =
         });
 
         it("[attr~=val]", () => {
             const expected = document.getElementById("attr-test-3");
-            expect(
-                CSSselect.selectAll("#attributes div[test~=three]", document)[0]
-            ).toBe(expected); // Found attribute with ~=
+            expect(selectAll("#attributes div[test~=three]")[0]).toBe(expected); // Found attribute with ~=
         });
 
         it("[attr|=val]", () => {
             const expected = document.getElementById("attr-test-2");
-            expect(
-                CSSselect.selectAll(
-                    '#attributes div[test|="two-foo"]',
-                    document
-                )[0]
-            ).toBe(expected); // Found attribute with |=
-            expect(
-                CSSselect.selectAll("#attributes div[test|=two]", document)[0]
-            ).toBe(expected); // Found attribute with |=
+            expect(selectAll('#attributes div[test|="two-foo"]')[0]).toBe(
+                expected
+            ); // Found attribute with |=
+            expect(selectAll("#attributes div[test|=two]")[0]).toBe(expected); // Found attribute with |=
         });
 
         it("[href=#x] special case", () => {
             const expected = document.getElementById("attr-test-4");
-            expect(
-                CSSselect.selectAll('#attributes a[href="#aname"]', document)[0]
-            ).toBe(expected); // Found attribute with href=#x
+            expect(selectAll('#attributes a[href="#aname"]')[0]).toBe(expected); // Found attribute with href=#x
         });
 
         /* CSS 3 SPEC */
 
         it("[attr^=val]", () => {
             const expected = document.getElementById("attr-test-2");
-            expect(
-                CSSselect.selectAll("#attributes div[test^=two]", document)[0]
-            ).toBe(expected); // Found attribute with ^=
+            expect(selectAll("#attributes div[test^=two]")[0]).toBe(expected); // Found attribute with ^=
         });
 
         it("[attr$=val]", () => {
             const expected = document.getElementById("attr-test-2");
-            expect(
-                CSSselect.selectAll("#attributes div[test$=foo]", document)[0]
-            ).toBe(expected); // Found attribute with $=
+            expect(selectAll("#attributes div[test$=foo]")[0]).toBe(expected); // Found attribute with $=
         });
 
         it("[attr*=val]", () => {
             const expected = document.getElementById("attr-test-3");
-            expect(
-                CSSselect.selectAll("#attributes div[test*=hree]", document)[0]
-            ).toBe(expected); // Found attribute with *=
+            expect(selectAll("#attributes div[test*=hree]")[0]).toBe(expected); // Found attribute with *=
         });
 
         it("direct descendants", () => {
+            expect(selectAll("#direct-descend > .direct-descend")).toHaveLength(
+                2
+            ); // Found two direct descendents
             expect(
-                CSSselect.selectAll(
-                    "#direct-descend > .direct-descend",
-                    document
-                )
-            ).toHaveLength(2); // Found two direct descendents
-            expect(
-                CSSselect.selectAll(
-                    "#direct-descend > .direct-descend > .lvl2",
-                    document
-                )
+                selectAll("#direct-descend > .direct-descend > .lvl2")
             ).toHaveLength(3); // Found three second-level direct descendents
         });
 
         it("sibling elements", () => {
             expect(
-                CSSselect.selectAll(
-                    "#sibling-selector ~ .sibling-selector",
-                    document
-                )
+                selectAll("#sibling-selector ~ .sibling-selector")
             ).toHaveLength(2); // Found two siblings
             expect(
-                CSSselect.selectAll(
-                    "#sibling-selector ~ div.sibling-selector",
-                    document
-                )
+                selectAll("#sibling-selector ~ div.sibling-selector")
             ).toHaveLength(2); // Found two siblings
             expect(
-                CSSselect.selectAll(
-                    "#sibling-selector + div.sibling-selector",
-                    document
-                )
+                selectAll("#sibling-selector + div.sibling-selector")
             ).toHaveLength(1); // Found one sibling
             expect(
-                CSSselect.selectAll(
-                    "#sibling-selector + .sibling-selector",
-                    document
-                )
+                selectAll("#sibling-selector + .sibling-selector")
             ).toHaveLength(1); // Found one sibling
 
-            expect(
-                CSSselect.selectAll(".parent .oldest ~ .sibling", document)
-            ).toHaveLength(4); // Found four younger siblings
-            expect(
-                CSSselect.selectAll(".parent .middle ~ .sibling", document)
-            ).toHaveLength(2); // Found two younger siblings
-            expect(
-                CSSselect.selectAll(".parent .middle ~ h4", document)
-            ).toHaveLength(1); // Found next sibling by tag
-            expect(
-                CSSselect.selectAll(".parent .middle ~ h4.younger", document)
-            ).toHaveLength(1); // Found next sibling by tag and class
-            expect(
-                CSSselect.selectAll(".parent .middle ~ h3", document)
-            ).toHaveLength(0); // An element can't be its own sibling
-            expect(
-                CSSselect.selectAll(".parent .middle ~ h2", document)
-            ).toHaveLength(0); // Didn't find an older sibling
-            expect(
-                CSSselect.selectAll(".parent .youngest ~ .sibling", document)
-            ).toHaveLength(0); // Found no younger siblings
+            expect(selectAll(".parent .oldest ~ .sibling")).toHaveLength(4); // Found four younger siblings
+            expect(selectAll(".parent .middle ~ .sibling")).toHaveLength(2); // Found two younger siblings
+            expect(selectAll(".parent .middle ~ h4")).toHaveLength(1); // Found next sibling by tag
+            expect(selectAll(".parent .middle ~ h4.younger")).toHaveLength(1); // Found next sibling by tag and class
+            expect(selectAll(".parent .middle ~ h3")).toHaveLength(0); // An element can't be its own sibling
+            expect(selectAll(".parent .middle ~ h2")).toHaveLength(0); // Didn't find an older sibling
+            expect(selectAll(".parent .youngest ~ .sibling")).toHaveLength(0); // Found no younger siblings
 
-            expect(
-                CSSselect.selectAll(".parent .oldest + .sibling", document)
-            ).toHaveLength(1); // Found next sibling
-            expect(
-                CSSselect.selectAll(".parent .middle + .sibling", document)
-            ).toHaveLength(1); // Found next sibling
-            expect(
-                CSSselect.selectAll(".parent .middle + h4", document)
-            ).toHaveLength(1); // Found next sibling by tag
-            expect(
-                CSSselect.selectAll(".parent .middle + h3", document)
-            ).toHaveLength(0); // An element can't be its own sibling
-            expect(
-                CSSselect.selectAll(".parent .middle + h2", document)
-            ).toHaveLength(0); // Didn't find an older sibling
-            expect(
-                CSSselect.selectAll(".parent .youngest + .sibling", document)
-            ).toHaveLength(0); // Found no younger siblings
+            expect(selectAll(".parent .oldest + .sibling")).toHaveLength(1); // Found next sibling
+            expect(selectAll(".parent .middle + .sibling")).toHaveLength(1); // Found next sibling
+            expect(selectAll(".parent .middle + h4")).toHaveLength(1); // Found next sibling by tag
+            expect(selectAll(".parent .middle + h3")).toHaveLength(0); // An element can't be its own sibling
+            expect(selectAll(".parent .middle + h2")).toHaveLength(0); // Didn't find an older sibling
+            expect(selectAll(".parent .youngest + .sibling")).toHaveLength(0); // Found no younger siblings
         });
     });
 
     describe("element-context queries", () => {
         it("relationship-first queries", () => {
             expect(
-                CSSselect.selectAll(
-                    "> .direct-descend",
-                    CSSselect.selectAll("#direct-descend", document)
-                )
+                selectAll("> .direct-descend", selectAll("#direct-descend"))
             ).toHaveLength(2); // Found two direct descendents using > first
             expect(
-                CSSselect.selectAll(
-                    "~ .sibling-selector",
-                    CSSselect.selectAll("#sibling-selector", document)
-                )
+                selectAll("~ .sibling-selector", selectAll("#sibling-selector"))
             ).toHaveLength(2); // Found two siblings with ~ first
             expect(
-                CSSselect.selectAll(
-                    "+ .sibling-selector",
-                    CSSselect.selectAll("#sibling-selector", document)
-                )
+                selectAll("+ .sibling-selector", selectAll("#sibling-selector"))
             ).toHaveLength(1); // Found one sibling with + first
             expect(
-                CSSselect.selectAll(
-                    "> .tokens a",
-                    CSSselect.selectAll(".idless", document)[0]
-                )
+                selectAll("> .tokens a", selectAll(".idless")[0])
             ).toHaveLength(1); // Found one sibling from a root with no id
         });
 
         // Should be able to query on an element that hasn't been inserted into the dom
         it("detached fragments", () => {
-            expect(CSSselect.selectAll(".a span", frag)).toHaveLength(1); // Should find child elements of fragment
-            expect(CSSselect.selectAll("> div p em", frag)).toHaveLength(2); // Should find child elements of fragment, relationship first
+            expect(selectAll(".a span", frag)).toHaveLength(1); // Should find child elements of fragment
+            expect(selectAll("> div p em", frag)).toHaveLength(2); // Should find child elements of fragment, relationship first
         });
 
         it("byId sub-queries within detached fragment", () => {
-            expect(CSSselect.selectAll("#emem", frag)).toHaveLength(1); // Found "#id" in fragment
-            expect(CSSselect.selectAll(".d.i #emem", frag)).toHaveLength(1); // Found ".class.class #id" in fragment
-            expect(CSSselect.selectAll(".d #oooo #emem", frag)).toHaveLength(1); // Found ".class #id #id" in fragment
-            expect(CSSselect.selectAll("> div #oooo", frag)).toHaveLength(1); // Found "> .class #id" in fragment
-            expect(
-                CSSselect.selectAll("#oooo", CSSselect.selectAll("#emem", frag))
-            ).toHaveLength(0); // Shouldn't find #oooo (ancestor) within #emem (descendent)
-            expect(
-                CSSselect.selectAll("#sep", CSSselect.selectAll("#emem", frag))
-            ).toHaveLength(0); // Shouldn't find #sep within #emem (unrelated)
+            expect(selectAll("#emem", frag)).toHaveLength(1); // Found "#id" in fragment
+            expect(selectAll(".d.i #emem", frag)).toHaveLength(1); // Found ".class.class #id" in fragment
+            expect(selectAll(".d #oooo #emem", frag)).toHaveLength(1); // Found ".class #id #id" in fragment
+            expect(selectAll("> div #oooo", frag)).toHaveLength(1); // Found "> .class #id" in fragment
+            expect(selectAll("#oooo", selectAll("#emem", frag))).toHaveLength(
+                0
+            ); // Shouldn't find #oooo (ancestor) within #emem (descendent)
+            expect(selectAll("#sep", selectAll("#emem", frag))).toHaveLength(0); // Shouldn't find #sep within #emem (unrelated)
         });
 
         it("exclude self in match", () => {
             expect(
-                CSSselect.selectAll(
-                    ".order-matters",
-                    CSSselect.selectAll("#order-matters", document)[0]
-                )
+                selectAll(".order-matters", selectAll("#order-matters")[0])
             ).toHaveLength(4); // Should not include self in element-context queries
         });
 
         // Because form's have .length
         it("forms can be used as contexts", () => {
-            expect(
-                CSSselect.selectAll(
-                    "*",
-                    CSSselect.selectAll("form", document)[0]
-                )
-            ).toHaveLength(3); // Found 3 elements under &lt;form&gt;
+            expect(selectAll("*", selectAll("form")[0])).toHaveLength(3); // Found 3 elements under &lt;form&gt;
         });
     });
 
     describe("tokenizer", () => {
         it("should not get weird tokens", () => {
+            expect(selectAll('div .tokens[title="one"]')[0]).toBe(
+                document.getElementById("token-one")
+            ); // Found div .tokens[title="one"]
+            expect(selectAll('div .tokens[title="one two"]')[0]).toBe(
+                document.getElementById("token-two")
+            ); // Found div .tokens[title="one two"]
+            expect(selectAll('div .tokens[title="one two three #%"]')[0]).toBe(
+                document.getElementById("token-three")
+            ); // Found div .tokens[title="one two three #%"]
             expect(
-                CSSselect.selectAll('div .tokens[title="one"]', document)[0]
-            ).toBe(document.getElementById("token-one")); // Found div .tokens[title="one"]
-            expect(
-                CSSselect.selectAll('div .tokens[title="one two"]', document)[0]
-            ).toBe(document.getElementById("token-two")); // Found div .tokens[title="one two"]
-            expect(
-                CSSselect.selectAll(
-                    'div .tokens[title="one two three #%"]',
-                    document
-                )[0]
-            ).toBe(document.getElementById("token-three")); // Found div .tokens[title="one two three #%"]
-            expect(
-                CSSselect.selectAll(
-                    "div .tokens[title='one two three #%'] a",
-                    document
-                )[0]
+                selectAll("div .tokens[title='one two three #%'] a")[0]
             ).toBe(document.getElementById("token-four")); // Found div .tokens[title=\'one two three #%\'] a
             expect(
-                CSSselect.selectAll(
-                    'div .tokens[title="one two three #%"] a[href$=foo] div',
-                    document
+                selectAll(
+                    'div .tokens[title="one two three #%"] a[href$=foo] div'
                 )[0]
             ).toBe(document.getElementById("token-five")); // Found div .tokens[title="one two three #%"] a[href=foo] div
         });
@@ -526,8 +343,7 @@ describe("qwery", () => {
     describe("interesting syntaxes", () => {
         it("should parse bad selectors", () => {
             expect(
-                CSSselect.selectAll("#spaced-tokens    p    em    a", document)
-                    .length
+                selectAll("#spaced-tokens    p    em    a").length
             ).toBeTruthy(); // Found element with funny tokens
         });
     });
@@ -546,10 +362,7 @@ describe("qwery", () => {
             function tag(el: Element) {
                 return el.name.toLowerCase();
             }
-            const els = CSSselect.selectAll<AnyNode, ParentNode>(
-                "#order-matters .order-matters",
-                document
-            ) as Element[];
+            const els = selectAll("#order-matters .order-matters") as Element[];
             expect(tag(els[0])).toBe("p"); // First element matched is a {p} tag
             expect(tag(els[1])).toBe("a"); // First element matched is a {a} tag
             expect(tag(els[2])).toBe("em"); // First element matched is a {em} tag
@@ -559,239 +372,140 @@ describe("qwery", () => {
 
     describe("pseudo-selectors", () => {
         it(":contains", () => {
-            expect(
-                CSSselect.selectAll("li:contains(humans)", document)
-            ).toHaveLength(1); // Found by "element:contains(text)"
-            expect(
-                CSSselect.selectAll(":contains(humans)", document)
-            ).toHaveLength(5); // Found by ":contains(text)", including all ancestors
+            expect(selectAll("li:contains(humans)")).toHaveLength(1); // Found by "element:contains(text)"
+            expect(selectAll(":contains(humans)")).toHaveLength(5); // Found by ":contains(text)", including all ancestors
             // * Is an important case, can cause weird errors
-            expect(
-                CSSselect.selectAll("*:contains(humans)", document)
-            ).toHaveLength(5); // Found by "*:contains(text)", including all ancestors
-            expect(
-                CSSselect.selectAll("ol:contains(humans)", document)
-            ).toHaveLength(1); // Found by "ancestor:contains(text)"
+            expect(selectAll("*:contains(humans)")).toHaveLength(5); // Found by "*:contains(text)", including all ancestors
+            expect(selectAll("ol:contains(humans)")).toHaveLength(1); // Found by "ancestor:contains(text)"
         });
 
         it(":not", () => {
-            expect(CSSselect.selectAll(".odd:not(div)", document)).toHaveLength(
-                1
-            ); // Found one .odd :not an &lt;a&gt;
+            expect(selectAll(".odd:not(div)")).toHaveLength(1); // Found one .odd :not an &lt;a&gt;
         });
 
         it(":first-child", () => {
-            expect(
-                CSSselect.selectAll("#pseudos div:first-child", document)[0]
-            ).toBe(pseudos[0]); // Found first child
-            expect(
-                CSSselect.selectAll("#pseudos div:first-child", document)
-            ).toHaveLength(1); // Found only 1
+            expect(selectAll("#pseudos div:first-child")[0]).toBe(pseudos[0]); // Found first child
+            expect(selectAll("#pseudos div:first-child")).toHaveLength(1); // Found only 1
         });
 
         it(":last-child", () => {
             const all = DomUtils.getElementsByTagName("div", pseudos);
-            expect(
-                CSSselect.selectAll("#pseudos div:last-child", document)[0]
-            ).toBe(all[all.length - 1]); // Found last child
-            expect(
-                CSSselect.selectAll("#pseudos div:last-child", document)
-            ).toHaveLength(1); // Found only 1
+            expect(selectAll("#pseudos div:last-child")[0]).toBe(
+                all[all.length - 1]
+            ); // Found last child
+            expect(selectAll("#pseudos div:last-child")).toHaveLength(1); // Found only 1
         });
 
         it('ol > li[attr="boosh"]:last-child', () => {
             const expected = document.getElementById("attr-child-boosh");
-            expect(
-                CSSselect.selectAll(
-                    'ol > li[attr="boosh"]:last-child',
-                    document
-                )
-            ).toHaveLength(1); // Only 1 element found
-            expect(
-                CSSselect.selectAll(
-                    'ol > li[attr="boosh"]:last-child',
-                    document
-                )[0]
-            ).toBe(expected); // Found correct element
+            expect(selectAll('ol > li[attr="boosh"]:last-child')).toHaveLength(
+                1
+            ); // Only 1 element found
+            expect(selectAll('ol > li[attr="boosh"]:last-child')[0]).toBe(
+                expected
+            ); // Found correct element
         });
 
         it(":nth-child(odd|even|x)", () => {
             const second = DomUtils.getElementsByTagName("div", pseudos)[1];
-            expect(
-                CSSselect.selectAll("#pseudos :nth-child(odd)", document)
-            ).toHaveLength(4); // Found 4 odd elements
-            expect(
-                CSSselect.selectAll("#pseudos div:nth-child(odd)", document)
-            ).toHaveLength(3); // Found 3 odd elements with div tag
-            expect(
-                CSSselect.selectAll("#pseudos div:nth-child(even)", document)
-            ).toHaveLength(3); // Found 3 even elements with div tag
-            expect(
-                CSSselect.selectAll("#pseudos div:nth-child(2)", document)[0]
-            ).toBe(second); // Found 2nd nth-child of pseudos
+            expect(selectAll("#pseudos :nth-child(odd)")).toHaveLength(4); // Found 4 odd elements
+            expect(selectAll("#pseudos div:nth-child(odd)")).toHaveLength(3); // Found 3 odd elements with div tag
+            expect(selectAll("#pseudos div:nth-child(even)")).toHaveLength(3); // Found 3 even elements with div tag
+            expect(selectAll("#pseudos div:nth-child(2)")[0]).toBe(second); // Found 2nd nth-child of pseudos
         });
 
         it(":nth-child(expr)", () => {
             const fifth = DomUtils.getElementsByTagName("a", pseudos)[0];
             const sixth = DomUtils.getElementsByTagName("div", pseudos)[4];
 
-            expect(
-                CSSselect.selectAll("#pseudos :nth-child(3n+1)", document)
-            ).toHaveLength(3); // Found 3 elements
-            expect(
-                CSSselect.selectAll("#pseudos :nth-child(+3n-2)", document)
-            ).toHaveLength(3); // Found 3 elements'
-            expect(
-                CSSselect.selectAll("#pseudos :nth-child(-n+6)", document)
-            ).toHaveLength(6); // Found 6 elements
-            expect(
-                CSSselect.selectAll("#pseudos :nth-child(-n+5)", document)
-            ).toHaveLength(5); // Found 5 elements
-            expect(
-                CSSselect.selectAll("#pseudos :nth-child(3n+2)", document)[1]
-            ).toBe(fifth); // Second :nth-child(3n+2) is the fifth child
-            expect(
-                CSSselect.selectAll("#pseudos :nth-child(3n)", document)[1]
-            ).toBe(sixth); // Second :nth-child(3n) is the sixth child
+            expect(selectAll("#pseudos :nth-child(3n+1)")).toHaveLength(3); // Found 3 elements
+            expect(selectAll("#pseudos :nth-child(+3n-2)")).toHaveLength(3); // Found 3 elements'
+            expect(selectAll("#pseudos :nth-child(-n+6)")).toHaveLength(6); // Found 6 elements
+            expect(selectAll("#pseudos :nth-child(-n+5)")).toHaveLength(5); // Found 5 elements
+            expect(selectAll("#pseudos :nth-child(3n+2)")[1]).toBe(fifth); // Second :nth-child(3n+2) is the fifth child
+            expect(selectAll("#pseudos :nth-child(3n)")[1]).toBe(sixth); // Second :nth-child(3n) is the sixth child
         });
 
         it(":nth-last-child(odd|even|x)", () => {
             const second = DomUtils.getElementsByTagName("div", pseudos)[1];
-            expect(
-                CSSselect.selectAll("#pseudos :nth-last-child(odd)", document)
-            ).toHaveLength(4); // Found 4 odd elements
-            expect(
-                CSSselect.selectAll(
-                    "#pseudos div:nth-last-child(odd)",
-                    document
-                )
-            ).toHaveLength(3); // Found 3 odd elements with div tag
-            expect(
-                CSSselect.selectAll(
-                    "#pseudos div:nth-last-child(even)",
-                    document
-                )
-            ).toHaveLength(3); // Found 3 even elements with div tag
-            expect(
-                CSSselect.selectAll(
-                    "#pseudos div:nth-last-child(6)",
-                    document
-                )[0]
-            ).toBe(second); // 6th nth-last-child should be 2nd of 7 elements
+            expect(selectAll("#pseudos :nth-last-child(odd)")).toHaveLength(4); // Found 4 odd elements
+            expect(selectAll("#pseudos div:nth-last-child(odd)")).toHaveLength(
+                3
+            ); // Found 3 odd elements with div tag
+            expect(selectAll("#pseudos div:nth-last-child(even)")).toHaveLength(
+                3
+            ); // Found 3 even elements with div tag
+            expect(selectAll("#pseudos div:nth-last-child(6)")[0]).toBe(second); // 6th nth-last-child should be 2nd of 7 elements
         });
 
         it(":nth-last-child(expr)", () => {
             const third = DomUtils.getElementsByTagName("div", pseudos)[2];
 
-            expect(
-                CSSselect.selectAll("#pseudos :nth-last-child(3n+1)", document)
-            ).toHaveLength(3); // Found 3 elements
-            expect(
-                CSSselect.selectAll("#pseudos :nth-last-child(3n-2)", document)
-            ).toHaveLength(3); // Found 3 elements
-            expect(
-                CSSselect.selectAll("#pseudos :nth-last-child(-n+6)", document)
-            ).toHaveLength(6); // Found 6 elements
-            expect(
-                CSSselect.selectAll("#pseudos :nth-last-child(-n+5)", document)
-            ).toHaveLength(5); // Found 5 elements
-            expect(
-                CSSselect.selectAll(
-                    "#pseudos :nth-last-child(3n+2)",
-                    document
-                )[0]
-            ).toBe(third); // First :nth-last-child(3n+2) is the third child
+            expect(selectAll("#pseudos :nth-last-child(3n+1)")).toHaveLength(3); // Found 3 elements
+            expect(selectAll("#pseudos :nth-last-child(3n-2)")).toHaveLength(3); // Found 3 elements
+            expect(selectAll("#pseudos :nth-last-child(-n+6)")).toHaveLength(6); // Found 6 elements
+            expect(selectAll("#pseudos :nth-last-child(-n+5)")).toHaveLength(5); // Found 5 elements
+            expect(selectAll("#pseudos :nth-last-child(3n+2)")[0]).toBe(third); // First :nth-last-child(3n+2) is the third child
         });
 
         it(":nth-of-type(expr)", () => {
             const a = DomUtils.getElementsByTagName("a", pseudos)[0];
 
-            expect(
-                CSSselect.selectAll("#pseudos div:nth-of-type(3n+1)", document)
-            ).toHaveLength(2); // Found 2 div elements
-            expect(
-                CSSselect.selectAll("#pseudos a:nth-of-type(3n+1)", document)
-            ).toHaveLength(1); // Found 1 a element
-            expect(
-                CSSselect.selectAll("#pseudos a:nth-of-type(3n+1)", document)[0]
-            ).toBe(a); // Found the right a element
-            expect(
-                CSSselect.selectAll("#pseudos a:nth-of-type(3n)", document)
-            ).toHaveLength(0); // No matches for every third a
-            expect(
-                CSSselect.selectAll("#pseudos a:nth-of-type(odd)", document)
-            ).toHaveLength(1); // Found the odd a
-            expect(
-                CSSselect.selectAll("#pseudos a:nth-of-type(1)", document)
-            ).toHaveLength(1); // Found the first a
+            expect(selectAll("#pseudos div:nth-of-type(3n+1)")).toHaveLength(2); // Found 2 div elements
+            expect(selectAll("#pseudos a:nth-of-type(3n+1)")).toHaveLength(1); // Found 1 a element
+            expect(selectAll("#pseudos a:nth-of-type(3n+1)")[0]).toBe(a); // Found the right a element
+            expect(selectAll("#pseudos a:nth-of-type(3n)")).toHaveLength(0); // No matches for every third a
+            expect(selectAll("#pseudos a:nth-of-type(odd)")).toHaveLength(1); // Found the odd a
+            expect(selectAll("#pseudos a:nth-of-type(1)")).toHaveLength(1); // Found the first a
         });
 
         it(":nth-last-of-type(expr)", () => {
             const second = DomUtils.getElementsByTagName("div", pseudos)[1];
 
             expect(
-                CSSselect.selectAll(
-                    "#pseudos div:nth-last-of-type(3n+1)",
-                    document
-                )
+                selectAll("#pseudos div:nth-last-of-type(3n+1)")
             ).toHaveLength(2); // Found 2 div elements
-            expect(
-                CSSselect.selectAll(
-                    "#pseudos a:nth-last-of-type(3n+1)",
-                    document
-                )
-            ).toHaveLength(1); // Found 1 a element
-            expect(
-                CSSselect.selectAll(
-                    "#pseudos div:nth-last-of-type(5)",
-                    document
-                )[0]
-            ).toBe(second); // 5th nth-last-of-type should be 2nd of 7 elements
+            expect(selectAll("#pseudos a:nth-last-of-type(3n+1)")).toHaveLength(
+                1
+            ); // Found 1 a element
+            expect(selectAll("#pseudos div:nth-last-of-type(5)")[0]).toBe(
+                second
+            ); // 5th nth-last-of-type should be 2nd of 7 elements
         });
 
         it(":first-of-type", () => {
-            expect(
-                CSSselect.selectAll("#pseudos a:first-of-type", document)[0]
-            ).toBe(DomUtils.getElementsByTagName("a", pseudos)[0]); // Found first a element
-            expect(
-                CSSselect.selectAll("#pseudos a:first-of-type", document)
-            ).toHaveLength(1); // Found only 1
+            expect(selectAll("#pseudos a:first-of-type")[0]).toBe(
+                DomUtils.getElementsByTagName("a", pseudos)[0]
+            ); // Found first a element
+            expect(selectAll("#pseudos a:first-of-type")).toHaveLength(1); // Found only 1
         });
 
         it(":last-of-type", () => {
             const all = DomUtils.getElementsByTagName("div", pseudos);
-            expect(
-                CSSselect.selectAll("#pseudos div:last-of-type", document)[0]
-            ).toBe(all[all.length - 1]); // Found last div element
-            expect(
-                CSSselect.selectAll("#pseudos div:last-of-type", document)
-            ).toHaveLength(1); // Found only 1
+            expect(selectAll("#pseudos div:last-of-type")[0]).toBe(
+                all[all.length - 1]
+            ); // Found last div element
+            expect(selectAll("#pseudos div:last-of-type")).toHaveLength(1); // Found only 1
         });
 
         it(":only-of-type", () => {
-            expect(
-                CSSselect.selectAll("#pseudos a:only-of-type", document)[0]
-            ).toBe(DomUtils.getElementsByTagName("a", pseudos)[0]); // Found the only a element
-            expect(
-                CSSselect.selectAll("#pseudos a:first-of-type", document)
-            ).toHaveLength(1); // Found only 1
+            expect(selectAll("#pseudos a:only-of-type")[0]).toBe(
+                DomUtils.getElementsByTagName("a", pseudos)[0]
+            ); // Found the only a element
+            expect(selectAll("#pseudos a:first-of-type")).toHaveLength(1); // Found only 1
         });
 
         it(":target", () => {
             location.hash = "";
-            expect(
-                CSSselect.selectAll("#pseudos:target", document)
-            ).toHaveLength(0); // #pseudos is not the target
+            expect(selectAll("#pseudos:target")).toHaveLength(0); // #pseudos is not the target
             location.hash = "#pseudos";
-            expect(
-                CSSselect.selectAll("#pseudos:target", document)
-            ).toHaveLength(1); // Now #pseudos is the target
+            expect(selectAll("#pseudos:target")).toHaveLength(1); // Now #pseudos is the target
             location.hash = "";
         });
 
         it("custom pseudos", () => {
             // :humanoid implemented just for testing purposes
-            expect(CSSselect.selectAll(":humanoid", document)).toHaveLength(2); // Selected using custom pseudo
+            expect(selectAll(":humanoid")).toHaveLength(2); // Selected using custom pseudo
         });
     });
 
@@ -831,10 +545,7 @@ describe("qwery", () => {
                 CSSselect.is(el, "ol ol li#attr-child-boosh[attr=boosh]")
             ).toBeTruthy(); // Tag tag tag#id[attr=val]
             expect(
-                CSSselect.is(
-                    CSSselect.selectAll("#token-four", document)[0],
-                    "div#fixtures>div a"
-                )
+                CSSselect.is(selectAll("#token-four")[0], "div#fixtures>div a")
             ).toBeTruthy(); // Tag#id>tag tag where ambiguous middle tag requires backtracking
         });
 
@@ -842,34 +553,22 @@ describe("qwery", () => {
             expect(CSSselect.is(el, "li:contains(hello)")).toBe(true); // Matching :contains(text)
             expect(CSSselect.is(el, "li:contains(human)")).toBe(false); // Non-matching :contains(text)
             expect(
-                CSSselect.is(
-                    CSSselect.selectAll("#list>li", document)[2],
-                    ":humanoid"
-                )
+                CSSselect.is(selectAll("#list>li")[2], ":humanoid", options)
             ).toBe(true); // Matching custom pseudo
             expect(
-                CSSselect.is(
-                    CSSselect.selectAll("#list>li", document)[1],
-                    ":humanoid"
-                )
+                CSSselect.is(selectAll("#list>li")[1], ":humanoid", options)
             ).toBe(false); // Non-matching custom pseudo
         });
 
         it("context", () => {
             expect(
                 CSSselect.is(el, "li#attr-child-boosh[attr=boosh]", {
-                    context: CSSselect.selectAll<AnyNode, ParentNode>(
-                        "#list",
-                        document
-                    )[0],
+                    context: selectAll("#list")[0],
                 })
             ).toBeTruthy(); // Context
             expect(
                 CSSselect.is(el, "ol#list li#attr-child-boosh[attr=boosh]", {
-                    context: CSSselect.selectAll<AnyNode, ParentNode>(
-                        "#boosh",
-                        document
-                    )[0],
+                    context: selectAll("#boosh")[0],
                 })
             ).toBeFalsy(); // Wrong context
         });
@@ -877,75 +576,51 @@ describe("qwery", () => {
 
     describe("selecting elements in other documents", () => {
         it("get element by id", () => {
-            const result = CSSselect.selectAll("#hsoob", doc);
+            const result = selectAll("#hsoob", doc);
             expect(result[0]).toBeTruthy(); // Found element with id=hsoob
         });
 
         it("get elements by class", () => {
-            expect(CSSselect.selectAll("#hsoob .a", doc)).toHaveLength(2); // Found two elements
-            expect(CSSselect.selectAll("#hsoob div.a", doc)[0]).toBeTruthy(); // Found one element
-            expect(CSSselect.selectAll("#hsoob div", doc)).toHaveLength(2); // Found two {div} elements
-            expect(CSSselect.selectAll("#hsoob span", doc)[0]).toBeTruthy(); // Found one {span} element
-            expect(CSSselect.selectAll("#hsoob div div", doc)[0]).toBeTruthy(); // Found a single div
-            expect(CSSselect.selectAll("p.odd", doc)).toHaveLength(1); // Found single br
+            expect(selectAll("#hsoob .a", doc)).toHaveLength(2); // Found two elements
+            expect(selectAll("#hsoob div.a", doc)[0]).toBeTruthy(); // Found one element
+            expect(selectAll("#hsoob div", doc)).toHaveLength(2); // Found two {div} elements
+            expect(selectAll("#hsoob span", doc)[0]).toBeTruthy(); // Found one {span} element
+            expect(selectAll("#hsoob div div", doc)[0]).toBeTruthy(); // Found a single div
+            expect(selectAll("p.odd", doc)).toHaveLength(1); // Found single br
         });
 
         it("complex selectors", () => {
-            expect(CSSselect.selectAll(".d ~ .sib", doc)).toHaveLength(2); // Found one ~ sibling
-            expect(CSSselect.selectAll(".a .d + .sib", doc)).toHaveLength(1); // Found 2 + siblings
-            expect(CSSselect.selectAll("#hsoob > div > .h", doc)).toHaveLength(
-                1
-            ); // Found span using child selectors
-            expect(
-                CSSselect.selectAll('.a .d ~ .sib[test="f g"]', doc)
-            ).toHaveLength(1); // Found 1 ~ sibling with test attribute
+            expect(selectAll(".d ~ .sib", doc)).toHaveLength(2); // Found one ~ sibling
+            expect(selectAll(".a .d + .sib", doc)).toHaveLength(1); // Found 2 + siblings
+            expect(selectAll("#hsoob > div > .h", doc)).toHaveLength(1); // Found span using child selectors
+            expect(selectAll('.a .d ~ .sib[test="f g"]', doc)).toHaveLength(1); // Found 1 ~ sibling with test attribute
         });
 
         it("byId sub-queries", () => {
-            expect(CSSselect.selectAll("#hsoob #spanny", doc)).toHaveLength(1); // Found "#id #id" in frame
-            expect(CSSselect.selectAll(".a #spanny", doc)).toHaveLength(1); // Found ".class #id" in frame
-            expect(
-                CSSselect.selectAll(".a #booshTest #spanny", doc)
-            ).toHaveLength(1); // Found ".class #id #id" in frame
-            expect(CSSselect.selectAll("> #hsoob", doc)).toHaveLength(1); // Found "> #id" in frame
+            expect(selectAll("#hsoob #spanny", doc)).toHaveLength(1); // Found "#id #id" in frame
+            expect(selectAll(".a #spanny", doc)).toHaveLength(1); // Found ".class #id" in frame
+            expect(selectAll(".a #booshTest #spanny", doc)).toHaveLength(1); // Found ".class #id #id" in frame
+            expect(selectAll("> #hsoob", doc)).toHaveLength(1); // Found "> #id" in frame
         });
 
         it("byId sub-queries within sub-context", () => {
+            expect(selectAll("#spanny", selectAll("#hsoob", doc))).toHaveLength(
+                1
+            ); // Found "#id -> #id" in frame
             expect(
-                CSSselect.selectAll(
-                    "#spanny",
-                    CSSselect.selectAll("#hsoob", doc)
-                )
-            ).toHaveLength(1); // Found "#id -> #id" in frame
-            expect(
-                CSSselect.selectAll(
-                    ".a #spanny",
-                    CSSselect.selectAll("#hsoob", doc)
-                )
+                selectAll(".a #spanny", selectAll("#hsoob", doc))
             ).toHaveLength(1); // Found ".class #id" in frame
             expect(
-                CSSselect.selectAll(
-                    ".a #booshTest #spanny",
-                    CSSselect.selectAll("#hsoob", doc)
-                )
+                selectAll(".a #booshTest #spanny", selectAll("#hsoob", doc))
             ).toHaveLength(1); // Found ".class #id #id" in frame
             expect(
-                CSSselect.selectAll(
-                    ".a > #booshTest",
-                    CSSselect.selectAll("#hsoob", doc)
-                )
+                selectAll(".a > #booshTest", selectAll("#hsoob", doc))
             ).toHaveLength(1); // Found "> .class #id" in frame
             expect(
-                CSSselect.selectAll(
-                    "#booshTest",
-                    CSSselect.selectAll("#spanny", doc)
-                )
+                selectAll("#booshTest", selectAll("#spanny", doc))
             ).toHaveLength(0); // Shouldn't find #booshTest (ancestor) within #spanny (descendent)
             expect(
-                CSSselect.selectAll(
-                    "#booshTest",
-                    CSSselect.selectAll("#lonelyHsoob", doc)
-                )
+                selectAll("#booshTest", selectAll("#lonelyHsoob", doc))
             ).toHaveLength(0); // Shouldn't find #booshTest within #lonelyHsoob (unrelated)
         });
     });


### PR DESCRIPTION
This option allows users to specify pseudo-classes. This approach is favoured over extending the internal `filters`, `pseudos` and `aliases` objects, as different libraries can define their own versions of pseudo-classes.

Extending `filters`, `pseudos` and `aliases` is now deprecated.