### PR TITLE
Adding support for the lang pseudo selector

### DIFF
--- a/src/pseudo-selectors/filters.ts
+++ b/src/pseudo-selectors/filters.ts
@@ -1,6 +1,8 @@
 import getNCheck from "nth-check";
 import boolbase from "boolbase";
 import type { CompiledQuery, InternalOptions, Adapter } from "../types.js";
+import { attributeRules } from "../attributes";
+import { AttributeAction, SelectorType } from "css-what";
 
 export type Filter = <Node, ElementNode extends Node>(
     next: CompiledQuery<ElementNode>,
@@ -158,6 +160,21 @@ export const filters: Record<string, Filter> = {
     hover: dynamicStatePseudo("isHovered"),
     visited: dynamicStatePseudo("isVisited"),
     active: dynamicStatePseudo("isActive"),
+
+    lang(next, data, options) {
+        return attributeRules[AttributeAction.Equals](
+            next,
+            {
+                type: SelectorType.Attribute,
+                name: "lang",
+                value: data,
+                action: AttributeAction.Equals,
+                ignoreCase: null,
+                namespace: null,
+            },
+            options
+        );
+    },
 };
 
 /**

--- a/test/pseudo-classes.ts
+++ b/test/pseudo-classes.ts
@@ -4,7 +4,7 @@ import type { AnyNode, Element } from "domhandler";
 import type { Adapter } from "../src/types.js";
 
 const dom = parseDOM(
-    "<div><p>In the end, it doesn't really Matter.</p><div>Indeed-that's a delicate matter.</div>"
+    '<div><p lang="en">In the end, it doesn\'t really Matter.</p><div lang="en">Indeed-that\'s a delicate matter.</div>'
 ) as Element[];
 
 describe(":icontains", () => {
@@ -141,5 +141,13 @@ describe(":first-child", () => {
         const matches = CSSselect.selectAll(":first-child", dom, { adapter });
         expect(matches).toHaveLength(2);
         expect(matches).toStrictEqual([dom[0], dom[0].children[0]]);
+    });
+});
+
+describe(":lang", () => {
+    it("should match the correct lang", () => {
+        const matches = CSSselect.selectAll(":lang(en)", dom);
+        expect(matches).toHaveLength(2);
+        expect(matches).toStrictEqual([dom[0].children[0], dom[0].children[1]]);
     });
 });


### PR DESCRIPTION
- Currently css-select module throws since there is no definition for the lang pseudo selector present
- Adding implementation for lang pseudo selector which simply delegates to the attribute equality selector