### PR TITLE
fix(pseudos): Allow whitespace in `:empty`

### DIFF
--- a/src/pseudo-selectors/pseudos.ts
+++ b/src/pseudo-selectors/pseudos.ts
@@ -7,13 +7,23 @@ export type Pseudo = <Node, ElementNode extends Node>(
     subselect?: string | null
 ) => boolean;
 
+/**
+ * CSS limits the characters considered as whitespace to space, tab & line
+ * feed. We add carriage returns as htmlparser2 doesn't normalize them to
+ * line feeds.
+ *
+ * @see {@link https://www.w3.org/TR/css-text-3/#white-space}
+ */
+const isDocumentWhiteSpace = /^[ \t\r\n]*$/;
+
 // While filters are precompiled, pseudos get called when they are needed
 export const pseudos: Record<string, Pseudo> = {
     empty(elem, { adapter }) {
         return !adapter.getChildren(elem).some(
             (elem) =>
+                adapter.isTag(elem) ||
                 // FIXME: `getText` call is potentially expensive.
-                adapter.isTag(elem) || adapter.getText(elem) !== ""
+                !isDocumentWhiteSpace.test(adapter.getText(elem))
         );
     },
 

--- a/test/pseudo-classes.ts
+++ b/test/pseudo-classes.ts
@@ -1,5 +1,5 @@
 import * as CSSselect from "../src";
-import { DomUtils, parseDOM } from "htmlparser2";
+import { DomUtils, parseDocument, parseDOM } from "htmlparser2";
 import type { AnyNode, Element } from "domhandler";
 import type { Adapter } from "../src/types.js";
 
@@ -141,5 +141,32 @@ describe(":first-child", () => {
         const matches = CSSselect.selectAll(":first-child", dom, { adapter });
         expect(matches).toHaveLength(2);
         expect(matches).toStrictEqual([dom[0], dom[0].children[0]]);
+    });
+});
+
+describe(":empty", () => {
+    // Adopted from the example in https://www.w3.org/TR/selectors-4/#the-empty-pseudo
+
+    it("should match", () => {
+        const dom = parseDocument(`
+            <p></p>
+            <p>
+            <p> </p>
+            <p></p>
+        `);
+        const matches = CSSselect.selectAll("p:empty", dom);
+        expect(matches).toHaveLength(4);
+    });
+
+    it("should not match", () => {
+        const dom = parseDocument(`
+            <div>text</div>
+            <div><p></p></div>
+            <div>&nbsp;</div>
+            <div><p>bla</p></div>
+            <div>this is not <p>:empty</p></div>
+        `);
+        const matches = CSSselect.selectAll("div:empty", dom);
+        expect(matches).toHaveLength(0);
     });
 });


### PR DESCRIPTION
Fixes https://github.com/cheeriojs/cheerio/issues/2561

Note that the behaviour of `:empty` has changed in CSS4 — whitespace was previously not ignored.

Also note that this changes the behaviour of the `:parent` pseudo-class (which is a jQuery extension), as jQuery defines it as the opposite of `:empty`.