### PR TITLE
fix(pseudos): Don't cache context sensitive :has

### DIFF
--- a/src/compile.ts
+++ b/src/compile.ts
@@ -1,32 +1,17 @@
 import { parse, Selector, SelectorType } from "css-what";
 import * as boolbase from "boolbase";
-import { sortRules, isTraversal } from "./helpers/selectors.js";
-import { compileGeneralSelector } from "./general.js";
 import {
-    ensureIsTag,
-    PLACEHOLDER_ELEMENT,
-} from "./pseudo-selectors/subselects.js";
+    sortRules,
+    isTraversal,
+    includesScopePseudo,
+} from "./helpers/selectors.js";
+import { compileGeneralSelector } from "./general.js";
+import { PLACEHOLDER_ELEMENT } from "./pseudo-selectors/subselects.js";
 import type {
     CompiledQuery,
     InternalOptions,
     InternalSelector,
 } from "./types.js";
-
-/**
- * Compiles a selector to an executable function.
- *
- * @param selector Selector to compile.
- * @param options Compilation options.
- * @param context Optional context for the selector.
- */
-export function compile<Node, ElementNode extends Node>(
-    selector: string | Selector[][],
-    options: InternalOptions<Node, ElementNode>,
-    context?: Node[] | Node
-): CompiledQuery<Node> {
-    const next = compileUnsafe(selector, options, context);
-    return ensureIsTag(next, options.adapter);
-}
 
 export function compileUnsafe<Node, ElementNode extends Node>(
     selector: string | Selector[][],
@@ -35,15 +20,6 @@ export function compileUnsafe<Node, ElementNode extends Node>(
 ): CompiledQuery<ElementNode> {
     const token = typeof selector === "string" ? parse(selector) : selector;
     return compileToken<Node, ElementNode>(token, options, context);
-}
-
-function includesScopePseudo(t: InternalSelector): boolean {
-    return (
-        t.type === SelectorType.Pseudo &&
-        (t.name === "scope" ||
-            (Array.isArray(t.data) &&
-                t.data.some((data) => data.some(includesScopePseudo))))
-    );
 }
 
 const DESCENDANT_TOKEN: Selector = { type: SelectorType.Descendant };

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -1,4 +1,4 @@
-import { parse, Selector, SelectorType } from "css-what";
+import { Selector, SelectorType } from "css-what";
 import * as boolbase from "boolbase";
 import {
     sortRules,
@@ -12,15 +12,6 @@ import type {
     InternalOptions,
     InternalSelector,
 } from "./types.js";
-
-export function compileUnsafe<Node, ElementNode extends Node>(
-    selector: string | Selector[][],
-    options: InternalOptions<Node, ElementNode>,
-    context?: Node[] | Node
-): CompiledQuery<ElementNode> {
-    const token = typeof selector === "string" ? parse(selector) : selector;
-    return compileToken<Node, ElementNode>(token, options, context);
-}
 
 const DESCENDANT_TOKEN: Selector = { type: SelectorType.Descendant };
 const FLEXIBLE_DESCENDANT_TOKEN: InternalSelector = {

--- a/src/helpers/querying.ts
+++ b/src/helpers/querying.ts
@@ -1,4 +1,4 @@
-import type { InternalOptions, Predicate } from "../types.js";
+import type { InternalOptions, Predicate, Adapter } from "../types.js";
 
 /**
  * Find all elements matching the query. If not in XML mode, the query will ignore
@@ -67,4 +67,15 @@ export function findOne<Node, ElementNode extends Node>(
     }
 
     return null;
+}
+
+export function getNextSiblings<Node, ElementNode extends Node>(
+    elem: Node,
+    adapter: Adapter<Node, ElementNode>
+): ElementNode[] {
+    const siblings = adapter.getSiblings(elem);
+    if (siblings.length <= 1) return [];
+    const elemIndex = siblings.indexOf(elem);
+    if (elemIndex < 0 || elemIndex === siblings.length - 1) return [];
+    return siblings.slice(elemIndex + 1).filter(adapter.isTag);
 }

--- a/src/helpers/selectors.ts
+++ b/src/helpers/selectors.ts
@@ -128,3 +128,12 @@ function getProcedure(token: InternalSelector): number {
         }
     }
 }
+
+export function includesScopePseudo(t: InternalSelector): boolean {
+    return (
+        t.type === SelectorType.Pseudo &&
+        (t.name === "scope" ||
+            (Array.isArray(t.data) &&
+                t.data.some((data) => data.some(includesScopePseudo))))
+    );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,7 +106,7 @@ function getSelectorFunc<Node, ElementNode extends Node, T>(
         const opts = convertOptionFormats(options);
 
         if (typeof query !== "function") {
-            query = compileUnsafe<Node, ElementNode>(query, opts, elements);
+            query = _compileUnsafe<Node, ElementNode>(query, opts, elements);
         }
 
         const filteredElements = prepareContext(

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,11 +4,8 @@ import type {
     AnyNode as DomHandlerNode,
     Element as DomHandlerElement,
 } from "domhandler";
-import {
-    compile as compileRaw,
-    compileUnsafe,
-    compileToken,
-} from "./compile.js";
+import type { Selector } from "css-what";
+import { compileUnsafe, compileToken } from "./compile.js";
 import type {
     CompiledQuery,
     Options,
@@ -17,8 +14,7 @@ import type {
     Adapter,
     Predicate,
 } from "./types.js";
-import { getNextSiblings } from "./pseudo-selectors/subselects.js";
-import { findAll, findOne } from "./helpers/querying.js";
+import { findAll, findOne, getNextSiblings } from "./helpers/querying.js";
 
 export type { Options };
 
@@ -63,9 +59,24 @@ function wrapCompile<Selector, Node, ElementNode extends Node, R extends Node>(
 }
 
 /**
- * Compiles the query, returns a function.
+ * Compiles a selector to an executable function.
+ *
+ * @param selector Selector to compile.
+ * @param options Compilation options.
+ * @param context Optional context for the selector.
  */
-export const compile = wrapCompile(compileRaw);
+export const compile = function compile<Node, ElementNode extends Node>(
+    selector: string | Selector[][],
+    options?: Options<Node, ElementNode>,
+    context?: Node[] | Node
+): CompiledQuery<Node> {
+    const opts = convertOptionFormats(options);
+    const next = compileUnsafe(selector, opts, context);
+
+    return next === boolbase.falseFunc
+        ? boolbase.falseFunc
+        : (elem: Node) => opts.adapter.isTag(elem) && next(elem);
+};
 export const _compileUnsafe = wrapCompile(compileUnsafe);
 export const _compileToken = wrapCompile(compileToken);
 
@@ -186,8 +197,7 @@ export function is<Node, ElementNode extends Node>(
     query: Query<ElementNode>,
     options?: Options<Node, ElementNode>
 ): boolean {
-    const opts = convertOptionFormats(options);
-    return (typeof query === "function" ? query : compileRaw(query, opts))(
+    return (typeof query === "function" ? query : compile(query, options))(
         elem
     );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,11 @@
 import * as DomUtils from "domutils";
 import * as boolbase from "boolbase";
+import { parse, type Selector } from "css-what";
 import type {
     AnyNode as DomHandlerNode,
     Element as DomHandlerElement,
 } from "domhandler";
-import type { Selector } from "css-what";
-import { compileUnsafe, compileToken } from "./compile.js";
+import { compileToken } from "./compile.js";
 import type {
     CompiledQuery,
     Options,
@@ -40,45 +40,56 @@ function convertOptionFormats<Node, ElementNode extends Node>(
     return opts as InternalOptions<Node, ElementNode>;
 }
 
-function wrapCompile<Selector, Node, ElementNode extends Node, R extends Node>(
-    func: (
-        selector: Selector,
-        options: InternalOptions<Node, ElementNode>,
-        context?: Node[] | Node
-    ) => CompiledQuery<R>
-) {
-    return function addAdapter(
-        selector: Selector,
-        options?: Options<Node, ElementNode>,
-        context?: Node[] | Node
-    ): CompiledQuery<R> {
-        const opts = convertOptionFormats(options);
-
-        return func(selector, opts, context);
-    };
-}
-
 /**
  * Compiles a selector to an executable function.
+ *
+ * The returned function checks if each passed node is an element. Use
+ * `_compileUnsafe` to skip this check.
  *
  * @param selector Selector to compile.
  * @param options Compilation options.
  * @param context Optional context for the selector.
  */
-export const compile = function compile<Node, ElementNode extends Node>(
+export function compile<Node, ElementNode extends Node>(
     selector: string | Selector[][],
     options?: Options<Node, ElementNode>,
     context?: Node[] | Node
 ): CompiledQuery<Node> {
     const opts = convertOptionFormats(options);
-    const next = compileUnsafe(selector, opts, context);
+    const next = _compileUnsafe(selector, opts, context);
 
     return next === boolbase.falseFunc
         ? boolbase.falseFunc
         : (elem: Node) => opts.adapter.isTag(elem) && next(elem);
-};
-export const _compileUnsafe = wrapCompile(compileUnsafe);
-export const _compileToken = wrapCompile(compileToken);
+}
+/**
+ * Like `compile`, but does not add a check if elements are tags.
+ */
+export function _compileUnsafe<Node, ElementNode extends Node>(
+    selector: string | Selector[][],
+    options?: Options<Node, ElementNode>,
+    context?: Node[] | Node
+): CompiledQuery<ElementNode> {
+    return _compileToken<Node, ElementNode>(
+        typeof selector === "string" ? parse(selector) : selector,
+        options,
+        context
+    );
+}
+/**
+ * @deprecated Use `_compileUnsafe` instead.
+ */
+export function _compileToken<Node, ElementNode extends Node>(
+    selector: Selector[][],
+    options?: Options<Node, ElementNode>,
+    context?: Node[] | Node
+): CompiledQuery<ElementNode> {
+    return compileToken<Node, ElementNode>(
+        selector,
+        convertOptionFormats(options),
+        context
+    );
+}
 
 function getSelectorFunc<Node, ElementNode extends Node, T>(
     searchFunc: (

--- a/test/pseudo-classes.ts
+++ b/test/pseudo-classes.ts
@@ -170,3 +170,33 @@ describe(":empty", () => {
         expect(matches).toHaveLength(0);
     });
 });
+
+describe(":has", () => {
+    it("should cache :has if applicable", () => {
+        const dom = parseDocument(`
+            <div>
+                <div class="a">
+                    <div class="b"></div>
+                    <div class="c"></div>
+                </div>
+                <div class="d"></div>
+            </div>
+        `);
+        const compiled = CSSselect.compile(":has(.a .b ~ .c)");
+
+        expect(
+            CSSselect.selectAll<AnyNode, Element>(compiled, dom)
+        ).toHaveLength(2);
+
+        (dom.childNodes[1] as any).childNodes[1].attribs.class = "";
+
+        // Should not find the element anymore
+        expect(CSSselect.selectAll<AnyNode, Element>(".a", dom)).toHaveLength(
+            0
+        );
+        // But as we have cached the results in `compiled`, we should succeed here.
+        expect(
+            CSSselect.selectAll<AnyNode, Element>(compiled, dom)
+        ).toHaveLength(2);
+    });
+});


### PR DESCRIPTION
`:has(:scope)` and `:has(> div)` were both previously cached, which they shouldn't have been.

As a bit of cleanup, this also moves the compile functions directly to the index file.