### PR TITLE
refactor: Move `getElementParent` to helpers

### DIFF
--- a/src/compile.ts
+++ b/src/compile.ts
@@ -12,6 +12,7 @@ import type {
     InternalOptions,
     InternalSelector,
 } from "./types.js";
+import { getElementParent } from "./helpers/querying.js";
 
 const DESCENDANT_TOKEN: Selector = { type: SelectorType.Descendant };
 const FLEXIBLE_DESCENDANT_TOKEN: InternalSelector = {
@@ -33,10 +34,11 @@ function absolutize<Node, ElementNode extends Node>(
     context?: Node[]
 ) {
     // TODO Use better check if the context is a document
-    const hasContext = !!context?.every((e) => {
-        const parent = adapter.isTag(e) && adapter.getParent(e);
-        return e === PLACEHOLDER_ELEMENT || (parent && adapter.isTag(parent));
-    });
+    const hasContext = !!context?.every(
+        (e) =>
+            e === PLACEHOLDER_ELEMENT ||
+            (adapter.isTag(e) && getElementParent(e, adapter) !== null)
+    );
 
     for (const t of token) {
         if (

--- a/src/general.ts
+++ b/src/general.ts
@@ -125,8 +125,8 @@ export function compileGeneralSelector<Node, ElementNode extends Node>(
         }
         case SelectorType.Child: {
             return function child(elem: ElementNode): boolean {
-                const parent = adapter.getParent(elem);
-                return parent != null && adapter.isTag(parent) && next(parent);
+                const parent = getElementParent(elem, adapter);
+                return parent !== null && next(parent);
             };
         }
         case SelectorType.Sibling: {

--- a/src/helpers/cache.ts
+++ b/src/helpers/cache.ts
@@ -1,4 +1,5 @@
 import type { CompiledQuery, InternalOptions } from "../types.js";
+import { getElementParent } from "./querying.js";
 
 /**
  * Some selectors such as `:contains` and (non-relative) `:has` will only be
@@ -14,7 +15,7 @@ export function cacheParentResults<Node, ElementNode extends Node>(
     { adapter, cacheResults }: InternalOptions<Node, ElementNode>,
     matches: (elem: ElementNode) => boolean
 ): CompiledQuery<ElementNode> {
-    if (cacheResults === false || typeof WeakSet === "undefined") {
+    if (cacheResults === false || typeof WeakMap === "undefined") {
         return (elem) => next(elem) && matches(elem);
     }
 
@@ -40,9 +41,9 @@ export function cacheParentResults<Node, ElementNode extends Node>(
         let node = elem;
 
         do {
-            const parent = adapter.getParent(node);
+            const parent = getElementParent(node, adapter);
 
-            if (parent == null || !adapter.isTag(parent)) {
+            if (parent === null) {
                 return addResultToCache(elem);
             }
 

--- a/src/helpers/querying.ts
+++ b/src/helpers/querying.ts
@@ -85,5 +85,5 @@ export function getElementParent<Node, ElementNode extends Node>(
     adapter: Adapter<Node, ElementNode>
 ): ElementNode | null {
     const parent = adapter.getParent(node);
-    return parent && adapter.isTag(parent) ? parent : null;
+    return parent != null && adapter.isTag(parent) ? parent : null;
 }

--- a/src/pseudo-selectors/pseudos.ts
+++ b/src/pseudo-selectors/pseudos.ts
@@ -19,11 +19,15 @@ const isDocumentWhiteSpace = /^[ \t\r\n]*$/;
 // While filters are precompiled, pseudos get called when they are needed
 export const pseudos: Record<string, Pseudo> = {
     empty(elem, { adapter }) {
-        return !adapter.getChildren(elem).some(
-            (elem) =>
-                adapter.isTag(elem) ||
+        const children = adapter.getChildren(elem);
+        return (
+            // First, make sure the tag does not have any element children.
+            children.every((elem) => !adapter.isTag(elem)) &&
+            // Then, check that the text content is only whitespace.
+            children.every((elem) =>
                 // FIXME: `getText` call is potentially expensive.
-                !isDocumentWhiteSpace.test(adapter.getText(elem))
+                isDocumentWhiteSpace.test(adapter.getText(elem))
+            )
         );
     },
 


### PR DESCRIPTION
We had the logic for this in many places.

Also includes a fix for a typo in the cache helper, and splits the checks for `:empty` between cheap end expensive ones.