### PR TITLE
refactor(querying): Don't flatten node stack

### DIFF
--- a/src/helpers/querying.ts
+++ b/src/helpers/querying.ts
@@ -4,7 +4,6 @@ import type { InternalOptions, Predicate, Adapter } from "../types.js";
  * Find all elements matching the query. If not in XML mode, the query will ignore
  * the contents of `<template>` elements.
  *
- *
  * @param query - Function that returns true if the element matches the query.
  * @param elems - Nodes to query. If a node is an element, its children will be queried.
  * @param options - Options for querying the document.
@@ -17,28 +16,49 @@ export function findAll<Node, ElementNode extends Node>(
 ): ElementNode[] {
     const { adapter, xmlMode = false } = options;
     const result: ElementNode[] = [];
-    const stack = elems.filter(adapter.isTag);
+    /** Stack of the arrays we are looking at. */
+    const nodeStack = [elems];
+    /** Stack of the indices within the arrays. */
+    const indexStack = [0];
 
-    let elem;
-    while ((elem = stack.shift())) {
-        if (xmlMode || adapter.getName(elem) !== "template") {
-            const children = adapter.getChildren(elem).filter(adapter.isTag);
-
-            if (children.length > 0) {
-                stack.unshift(...children);
+    for (;;) {
+        // First, check if the current array has any more elements to look at.
+        if (indexStack[0] >= nodeStack[0].length) {
+            // If we have no more arrays to look at, we are done.
+            if (nodeStack.length === 1) {
+                return result;
             }
+
+            nodeStack.shift();
+            indexStack.shift();
+
+            // Loop back to the start to continue with the next array.
+            continue;
         }
 
-        if (query(elem)) result.push(elem);
-    }
+        const elem = nodeStack[0][indexStack[0]++];
 
-    return result;
+        if (!adapter.isTag(elem)) continue;
+        if (query(elem)) result.push(elem);
+
+        if (xmlMode || adapter.getName(elem) !== "template") {
+            /*
+             * Add the children to the stack. We are depth-first, so this is
+             * the next array we look at.
+             */
+            const children = adapter.getChildren(elem);
+
+            if (children.length > 0) {
+                nodeStack.unshift(children);
+                indexStack.unshift(0);
+            }
+        }
+    }
 }
 
 /**
  * Find the first element matching the query. If not in XML mode, the query will ignore
  * the contents of `<template>` elements.
- *
  *
  * @param query - Function that returns true if the element matches the query.
  * @param elems - Nodes to query. If a node is an element, its children will be queried.
@@ -51,22 +71,44 @@ export function findOne<Node, ElementNode extends Node>(
     options: InternalOptions<Node, ElementNode>,
 ): ElementNode | null {
     const { adapter, xmlMode = false } = options;
-    const stack = elems.filter(adapter.isTag);
+    /** Stack of the arrays we are looking at. */
+    const nodeStack = [elems];
+    /** Stack of the indices within the arrays. */
+    const indexStack = [0];
 
-    let elem;
-    while ((elem = stack.shift())) {
-        if (xmlMode || adapter.getName(elem) !== "template") {
-            const children = adapter.getChildren(elem).filter(adapter.isTag);
-
-            if (children.length > 0) {
-                stack.unshift(...children);
+    for (;;) {
+        // First, check if the current array has any more elements to look at.
+        if (indexStack[0] >= nodeStack[0].length) {
+            // If we have no more arrays to look at, we are done.
+            if (nodeStack.length === 1) {
+                return null;
             }
+
+            nodeStack.shift();
+            indexStack.shift();
+
+            // Loop back to the start to continue with the next array.
+            continue;
         }
 
-        if (query(elem)) return elem;
-    }
+        const elem = nodeStack[0][indexStack[0]++];
 
-    return null;
+        if (!adapter.isTag(elem)) continue;
+        if (query(elem)) return elem;
+
+        if (xmlMode || adapter.getName(elem) !== "template") {
+            /*
+             * Add the children to the stack. We are depth-first, so this is
+             * the next array we look at.
+             */
+            const children = adapter.getChildren(elem);
+
+            if (children.length > 0) {
+                nodeStack.unshift(children);
+                indexStack.unshift(0);
+            }
+        }
+    }
 }
 
 export function getNextSiblings<Node, ElementNode extends Node>(


### PR DESCRIPTION
The node stack in query methods is now an array of arrays.