### PR TITLE
Add support for :read-only and :read-write pseudos

### DIFF
--- a/test/pseudo-classes.ts
+++ b/test/pseudo-classes.ts
@@ -200,3 +200,28 @@ describe(":has", () => {
         ).toHaveLength(2);
     });
 });
+
+describe(":read-only and :read-write", () => {
+    it("should match", () => {
+        const dom = parseDocument(`
+            <div>
+                <input type="text" readonly>
+                <input type="text">
+                <input type="color" readonly>
+                <input type="color">
+                <textarea readonly></textarea>
+                <textarea></textarea>
+            </div>
+        `);
+        const readonly = CSSselect.compile(":read-only");
+        const readwrite = CSSselect.compile(":read-write");
+
+        expect(
+            CSSselect.selectAll<AnyNode, Element>(readonly, dom),
+        ).toHaveLength(2);
+
+        expect(
+            CSSselect.selectAll<AnyNode, Element>(readwrite, dom),
+        ).toHaveLength(2);
+    });
+});


### PR DESCRIPTION
This PR adds support for the `:read-only` and `:read-write` pseudo-selectors, as described [here](https://developer.mozilla.org/en-US/docs/Web/CSS/:read-write).