### PR TITLE
Validate pseudo-class argument arity consistently

### DIFF
--- a/src/pseudo-selectors/index.ts
+++ b/src/pseudo-selectors/index.ts
@@ -42,10 +42,6 @@ const filtersWithoutArguments = new Set(
     [...allFilterNames].filter((filterName) => !filtersWithArguments.has(filterName)),
 );
 
-if (filtersWithArguments.size + filtersWithoutArguments.size !== allFilterNames.size) {
-    throw new Error("Filter argument validation sets are out of sync with filters");
-}
-
 /**
  * Compile a pseudo selector into an executable query function.
  * @param next Matcher to run after this matcher succeeds.

--- a/src/pseudo-selectors/index.ts
+++ b/src/pseudo-selectors/index.ts
@@ -78,7 +78,9 @@ export function compilePseudoSelector<Node, ElementNode extends Node>(
 
     if (typeof stringPseudo === "string") {
         if (data != null) {
-            throw new Error(`Pseudo ${name} doesn't have any arguments`);
+            throw new Error(
+                `Pseudo-class :${name} doesn't have any arguments`,
+            );
         }
 
         // The alias has to be parsed here, to make sure options are respected.

--- a/src/pseudo-selectors/index.ts
+++ b/src/pseudo-selectors/index.ts
@@ -59,12 +59,12 @@ export function compilePseudoSelector<Node, ElementNode extends Node>(
 ): CompiledQuery<ElementNode> {
     const { name, data } = selector;
 
-    if (data === null && name in subselects) {
+    if (data === null && Object.hasOwn(subselects, name)) {
         throw new Error(`Pseudo-class :${name} requires an argument`);
     }
 
     if (Array.isArray(data)) {
-        if (!(name in subselects)) {
+        if (!Object.hasOwn(subselects, name)) {
             throw new Error(`Unknown pseudo-class :${name}(${data})`);
         }
 
@@ -92,7 +92,7 @@ export function compilePseudoSelector<Node, ElementNode extends Node>(
         return (element) => userPseudo(element, data) && next(element);
     }
 
-    if (name in filters) {
+    if (Object.hasOwn(filters, name)) {
         if (data === null && filtersWithArguments.has(name)) {
             throw new Error(`Pseudo-class :${name} requires an argument`);
         }
@@ -110,7 +110,7 @@ export function compilePseudoSelector<Node, ElementNode extends Node>(
         );
     }
 
-    if (name in pseudos) {
+    if (Object.hasOwn(pseudos, name)) {
         const pseudo = pseudos[name];
         verifyPseudoArguments(pseudo, name, data, 2);
 

--- a/src/pseudo-selectors/index.ts
+++ b/src/pseudo-selectors/index.ts
@@ -20,6 +20,8 @@ import { filters } from "./filters.js";
 import { pseudos, verifyPseudoArguments } from "./pseudos.js";
 import { subselects } from "./subselects.js";
 
+const allFilterNames = new Set(Object.keys(filters));
+
 const filtersWithArguments = new Set([
     "contains",
     "icontains",
@@ -30,13 +32,19 @@ const filtersWithArguments = new Set([
     "lang",
 ]);
 
-const filtersWithoutArguments = new Set([
-    "root",
-    "scope",
-    "hover",
-    "visited",
-    "active",
-]);
+for (const filterName of filtersWithArguments) {
+    if (!allFilterNames.has(filterName)) {
+        throw new Error(`Unknown filter in filtersWithArguments: ${filterName}`);
+    }
+}
+
+const filtersWithoutArguments = new Set(
+    [...allFilterNames].filter((filterName) => !filtersWithArguments.has(filterName)),
+);
+
+if (filtersWithArguments.size + filtersWithoutArguments.size !== allFilterNames.size) {
+    throw new Error("Filter argument validation sets are out of sync with filters");
+}
 
 /**
  * Compile a pseudo selector into an executable query function.

--- a/src/pseudo-selectors/index.ts
+++ b/src/pseudo-selectors/index.ts
@@ -20,6 +20,24 @@ import { filters } from "./filters.js";
 import { pseudos, verifyPseudoArguments } from "./pseudos.js";
 import { subselects } from "./subselects.js";
 
+const filtersWithArguments = new Set([
+    "contains",
+    "icontains",
+    "nth-child",
+    "nth-last-child",
+    "nth-of-type",
+    "nth-last-of-type",
+    "lang",
+]);
+
+const filtersWithoutArguments = new Set([
+    "root",
+    "scope",
+    "hover",
+    "visited",
+    "active",
+]);
+
 /**
  * Compile a pseudo selector into an executable query function.
  * @param next Matcher to run after this matcher succeeds.
@@ -36,6 +54,10 @@ export function compilePseudoSelector<Node, ElementNode extends Node>(
     compileToken: CompileToken<Node, ElementNode>,
 ): CompiledQuery<ElementNode> {
     const { name, data } = selector;
+
+    if (data === null && name in subselects) {
+        throw new Error(`Pseudo-class :${name} requires an argument`);
+    }
 
     if (Array.isArray(data)) {
         if (!(name in subselects)) {
@@ -67,6 +89,14 @@ export function compilePseudoSelector<Node, ElementNode extends Node>(
     }
 
     if (name in filters) {
+        if (data === null && filtersWithArguments.has(name)) {
+            throw new Error(`Pseudo-class :${name} requires an argument`);
+        }
+
+        if (data !== null && filtersWithoutArguments.has(name)) {
+            throw new Error(`Pseudo-class :${name} doesn't have any arguments`);
+        }
+
         return filters[name](
             next,
             data as string,

--- a/test/pseudo-classes.ts
+++ b/test/pseudo-classes.ts
@@ -129,6 +129,14 @@ describe("unmatched", () => {
     });
 
     it("should throw when pseudo-classes are missing required arguments", () => {
+        expect(() => CSSselect.selectAll(":contains", dom)).toThrow(
+            "Pseudo-class :contains requires an argument",
+        );
+
+        expect(() => CSSselect.selectAll(":icontains", dom)).toThrow(
+            "Pseudo-class :icontains requires an argument",
+        );
+
         expect(() => CSSselect.selectAll(":lang", dom)).toThrow(
             "Pseudo-class :lang requires an argument",
         );
@@ -137,8 +145,32 @@ describe("unmatched", () => {
             "Pseudo-class :nth-child requires an argument",
         );
 
+        expect(() => CSSselect.selectAll(":nth-last-child", dom)).toThrow(
+            "Pseudo-class :nth-last-child requires an argument",
+        );
+
+        expect(() => CSSselect.selectAll(":nth-of-type", dom)).toThrow(
+            "Pseudo-class :nth-of-type requires an argument",
+        );
+
+        expect(() => CSSselect.selectAll(":nth-last-of-type", dom)).toThrow(
+            "Pseudo-class :nth-last-of-type requires an argument",
+        );
+
         expect(() => CSSselect.selectAll(":has", dom)).toThrow(
             "Pseudo-class :has requires an argument",
+        );
+
+        expect(() => CSSselect.selectAll(":is", dom)).toThrow(
+            "Pseudo-class :is requires an argument",
+        );
+
+        expect(() => CSSselect.selectAll(":matches", dom)).toThrow(
+            "Pseudo-class :matches requires an argument",
+        );
+
+        expect(() => CSSselect.selectAll(":where", dom)).toThrow(
+            "Pseudo-class :where requires an argument",
         );
 
         expect(() => CSSselect.selectAll(":not", dom)).toThrow(

--- a/test/pseudo-classes.ts
+++ b/test/pseudo-classes.ts
@@ -198,6 +198,10 @@ describe("unmatched", () => {
         expect(() => CSSselect.selectAll(":visited(foo)", dom)).toThrow(
             "Pseudo-class :visited doesn't have any arguments",
         );
+
+        expect(() => CSSselect.selectAll(":enabled(foo)", dom)).toThrow(
+            "Pseudo-class :enabled doesn't have any arguments",
+        );
     });
 });
 

--- a/test/pseudo-classes.ts
+++ b/test/pseudo-classes.ts
@@ -127,6 +127,34 @@ describe("unmatched", () => {
             "Unknown pseudo-class :host-context",
         );
     });
+
+    it("should throw when pseudo-classes are missing required arguments", () => {
+        expect(() => CSSselect.selectAll(":lang", dom)).toThrow(
+            "Pseudo-class :lang requires an argument",
+        );
+
+        expect(() => CSSselect.selectAll(":nth-child", dom)).toThrow(
+            "Pseudo-class :nth-child requires an argument",
+        );
+
+        expect(() => CSSselect.selectAll(":has", dom)).toThrow(
+            "Pseudo-class :has requires an argument",
+        );
+
+        expect(() => CSSselect.selectAll(":not", dom)).toThrow(
+            "Pseudo-class :not requires an argument",
+        );
+    });
+
+    it("should throw when argument-less pseudo-classes receive arguments", () => {
+        expect(() => CSSselect.selectAll(":scope(foo)", dom)).toThrow(
+            "Pseudo-class :scope doesn't have any arguments",
+        );
+
+        expect(() => CSSselect.selectAll(":active(foo)", dom)).toThrow(
+            "Pseudo-class :active doesn't have any arguments",
+        );
+    });
 });
 
 describe(":first-child", () => {

--- a/test/pseudo-classes.ts
+++ b/test/pseudo-classes.ts
@@ -202,6 +202,18 @@ describe("unmatched", () => {
         expect(() => CSSselect.selectAll(":enabled(foo)", dom)).toThrow(
             "Pseudo-class :enabled doesn't have any arguments",
         );
+
+        expect(() => CSSselect.selectAll(":root(foo)", dom)).toThrow(
+            "Pseudo-class :root doesn't have any arguments",
+        );
+
+        expect(() => CSSselect.selectAll(":hover(foo)", dom)).toThrow(
+            "Pseudo-class :hover doesn't have any arguments",
+        );
+
+        expect(() => CSSselect.selectAll(":visited(foo)", dom)).toThrow(
+            "Pseudo-class :visited doesn't have any arguments",
+        );
     });
 });
 

--- a/test/pseudo-classes.ts
+++ b/test/pseudo-classes.ts
@@ -186,6 +186,18 @@ describe("unmatched", () => {
         expect(() => CSSselect.selectAll(":active(foo)", dom)).toThrow(
             "Pseudo-class :active doesn't have any arguments",
         );
+
+        expect(() => CSSselect.selectAll(":root(foo)", dom)).toThrow(
+            "Pseudo-class :root doesn't have any arguments",
+        );
+
+        expect(() => CSSselect.selectAll(":hover(foo)", dom)).toThrow(
+            "Pseudo-class :hover doesn't have any arguments",
+        );
+
+        expect(() => CSSselect.selectAll(":visited(foo)", dom)).toThrow(
+            "Pseudo-class :visited doesn't have any arguments",
+        );
     });
 });
 

--- a/test/pseudo-classes.ts
+++ b/test/pseudo-classes.ts
@@ -202,18 +202,6 @@ describe("unmatched", () => {
         expect(() => CSSselect.selectAll(":enabled(foo)", dom)).toThrow(
             "Pseudo-class :enabled doesn't have any arguments",
         );
-
-        expect(() => CSSselect.selectAll(":root(foo)", dom)).toThrow(
-            "Pseudo-class :root doesn't have any arguments",
-        );
-
-        expect(() => CSSselect.selectAll(":hover(foo)", dom)).toThrow(
-            "Pseudo-class :hover doesn't have any arguments",
-        );
-
-        expect(() => CSSselect.selectAll(":visited(foo)", dom)).toThrow(
-            "Pseudo-class :visited doesn't have any arguments",
-        );
     });
 });
 


### PR DESCRIPTION
## Description:
- Add explicit argument validation for subselect pseudo-classes when called without required arguments.
- Add argument validation for filter pseudo-classes that require an argument.
- Reject arguments for filter pseudo-classes that do not accept them.
- Add regression tests for the affected selectors.

## Verification:

- npm run test:vi
- npm run build
- runtime check confirms clear 'arity' errors for :lang, :nth-child, :has, :not, and :scope(foo)

Fixes #1766

The screenshot of the tests run, for validation:

<img width="1222" height="842" alt="image" src="https://github.com/user-attachments/assets/969d1ee1-df8b-4798-9ecc-d92a79c6f8aa" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened and earlier validation of pseudo-class arguments so invalid selectors now throw clearer, consistent error messages; membership checks made more robust and one pseudo-class error message format standardized.

* **Tests**
  * Added tests that assert exact error messages for missing-required and for provided-disallowed pseudo-class arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->