### PR TITLE
feat: add :focus-visible and :focus-within support

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,9 @@ _As defined by CSS 4 and / or jQuery._
       elements that are links and have not been visited.
     - [`:visited`](https://developer.mozilla.org/en-US/docs/Web/CSS/:visited),
       [`:hover`](https://developer.mozilla.org/en-US/docs/Web/CSS/:hover),
-      [`:active`](https://developer.mozilla.org/en-US/docs/Web/CSS/:active)
+      [`:active`](https://developer.mozilla.org/en-US/docs/Web/CSS/:active),
+      [`:focus-visible`](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible),
+      [`:focus-within`](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-within)
       (these depend on optional `Adapter` methods, so these will only match
       elements if implemented in `Adapter`)
     - [`:checked`](https://developer.mozilla.org/en-US/docs/Web/CSS/:checked):

--- a/src/pseudo-selectors/filters.ts
+++ b/src/pseudo-selectors/filters.ts
@@ -209,6 +209,10 @@ export const filters: Record<string, Filter> = {
     active: dynamicStatePseudo("isActive"),
 };
 
+/**
+ * `:focus-within` matches an element that is focused or has a focused descendant.
+ * Depends on the optional `Adapter.isFocused` method.
+ */
 function focusWithinPseudo<Node, ElementNode extends Node>(
     next: CompiledQuery<ElementNode>,
     _rule: string,

--- a/src/pseudo-selectors/filters.ts
+++ b/src/pseudo-selectors/filters.ts
@@ -232,7 +232,8 @@ function focusWithinPseudo<Node, ElementNode extends Node>(
 
         const queue = [...adapter.getChildren(element)];
 
-        for (const node of queue) {
+        for (let index = 0; index < queue.length; index++) {
+            const node = queue[index];
             if (!adapter.isTag(node)) {
                 continue;
             }

--- a/src/pseudo-selectors/filters.ts
+++ b/src/pseudo-selectors/filters.ts
@@ -203,9 +203,46 @@ export const filters: Record<string, Filter> = {
     },
 
     hover: dynamicStatePseudo("isHovered"),
+    "focus-visible": dynamicStatePseudo("isFocusVisible"),
+    "focus-within": focusWithinPseudo,
     visited: dynamicStatePseudo("isVisited"),
     active: dynamicStatePseudo("isActive"),
 };
+
+function focusWithinPseudo<Node, ElementNode extends Node>(
+    next: CompiledQuery<ElementNode>,
+    _rule: string,
+    options: InternalOptions<Node, ElementNode>,
+): CompiledQuery<ElementNode> {
+    const { adapter } = options;
+    const isFocused = adapter.isFocused;
+
+    if (typeof isFocused !== "function") {
+        return boolbase.falseFunc;
+    }
+
+    return cacheParentResults(next, options, (element) => {
+        if (isFocused(element)) {
+            return true;
+        }
+
+        const queue = [...adapter.getChildren(element)];
+
+        for (const node of queue) {
+            if (!adapter.isTag(node)) {
+                continue;
+            }
+
+            if (isFocused(node)) {
+                return true;
+            }
+
+            queue.push(...adapter.getChildren(node));
+        }
+
+        return false;
+    });
+}
 
 /**
  * Dynamic state pseudos. These depend on optional Adapter methods.
@@ -213,7 +250,7 @@ export const filters: Record<string, Filter> = {
  * @returns Pseudo for the `filters` object.
  */
 function dynamicStatePseudo(
-    name: "isHovered" | "isVisited" | "isActive",
+    name: "isHovered" | "isFocusVisible" | "isVisited" | "isActive",
 ): Filter {
     return function dynamicPseudo(next, _rule, { adapter }) {
         const filterFunction = adapter[name];

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,6 +83,16 @@ export interface Adapter<Node, ElementNode extends Node> {
     isHovered?: (element: ElementNode) => boolean;
 
     /**
+     * Is the element focused?
+     */
+    isFocused?: (element: ElementNode) => boolean;
+
+    /**
+     * Is the element in focus-visible state?
+     */
+    isFocusVisible?: (element: ElementNode) => boolean;
+
+    /**
      * Is the element in visited state?
      */
     isVisited?: (element: ElementNode) => boolean;

--- a/test/api.ts
+++ b/test/api.ts
@@ -460,5 +460,56 @@ describe("API", () => {
             const dom = parseDocument(`${"<p>foo".repeat(10)}`);
             expect(CSSselect.selectAll("p:hover", dom)).toHaveLength(0);
         });
+
+        it("should support isFocusVisible", () => {
+            const dom = parseDocument(`${"<button>foo</button>".repeat(3)}`)
+                .children as Element[];
+
+            const adapter = {
+                ...DomUtils,
+                isTag,
+                isFocusVisible: (element: Element) =>
+                    element === dom[dom.length - 1],
+            };
+
+            const selection = CSSselect.selectAll("button:focus-visible", dom, {
+                adapter,
+            });
+            expect(selection).toHaveLength(1);
+            expect(selection[0]).toBe(dom[dom.length - 1]);
+        });
+
+        it("should not match any elements if `isFocusVisible` is not defined", () => {
+            const dom = parseDocument(`${"<button>foo</button>".repeat(3)}`);
+            expect(CSSselect.selectAll("button:focus-visible", dom)).toHaveLength(
+                0,
+            );
+        });
+
+        it("should support isFocused for :focus-within", () => {
+            const [dom] = parseDocument(
+                "<div><p><span>foo</span></p><p>bar</p></div>",
+            ).children as Element[];
+            const focused = ((dom.children[0] as Element).children[0] as Element);
+
+            const adapter = {
+                ...DomUtils,
+                isTag,
+                isFocused: (element: Element) => element === focused,
+            };
+
+            const selection = CSSselect.selectAll(":focus-within", [dom], {
+                adapter,
+            });
+            expect(selection).toHaveLength(3);
+            expect(selection).toContain(dom);
+            expect(selection).toContain(dom.children[0]);
+            expect(selection).toContain(focused);
+        });
+
+        it("should not match any elements if `isFocused` is not defined", () => {
+            const dom = parseDocument("<div><span>foo</span></div>");
+            expect(CSSselect.selectAll(":focus-within", dom)).toHaveLength(0);
+        });
     });
 });


### PR DESCRIPTION
## Description:

- Add :focus-visible support via an optional adapter isFocusVisible method.
- Add :focus-within support via an optional adapter isFocused method.
- Extend adapter typings for isFocused and isFocusVisible.
- Add regression tests for both selectors and fallback behavior when adapter methods are missing.
- Document the new pseudo-classes in the README.

## Verification:

- npm run test:vi
- npm run build
- runtime probe confirms :focus-visible and :focus-within now compile and match

Resolves #1768

#### The validation screenshot of the tests run, locally:

<img width="1274" height="699" alt="image" src="https://github.com/user-attachments/assets/2a3207a0-cd51-4dea-948a-14592b827793" />

<img width="1070" height="144" alt="image" src="https://github.com/user-attachments/assets/23058acc-a9dd-42a3-9680-1fe32b52ebd0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support added for :focus-visible and :focus-within pseudo-selectors

* **Documentation**
  * Updated supported selectors list to include :focus-visible and :focus-within with MDN links

* **Tests**
  * Added tests verifying :focus-visible and :focus-within behavior and fallbacks when focus-related hooks are not provided
<!-- end of auto-generated comment: release notes by coderabbit.ai -->