### PR TITLE
fix(attributes): `[attr~=""]` with an empty value matches nothing

### DIFF
--- a/src/attributes.ts
+++ b/src/attributes.ts
@@ -146,7 +146,12 @@ export const attributeRules: Record<
     element(next, data, options) {
         const { adapter } = options;
         const { name, value } = data;
-        if (whitespaceRe.test(value)) {
+        /*
+         * An empty value (or one containing whitespace, which can never be a
+         * single token) matches nothing — same as `^=`/`$=`/`*=` with an empty
+         * value. See https://www.w3.org/TR/selectors-4/#attribute-representation
+         */
+        if (value === "" || whitespaceRe.test(value)) {
             return boolbase.falseFunc;
         }
 

--- a/test/attributes.ts
+++ b/test/attributes.ts
@@ -91,6 +91,12 @@ describe("Attributes", () => {
             );
         });
 
+        it("should for ~= with an empty value", () => {
+            expect(CSSselect._compileUnsafe("[foo~='']")).toBe(
+                boolbase.falseFunc,
+            );
+        });
+
         it("should for $=", () => {
             expect(CSSselect._compileUnsafe("[foo$='']")).toBe(
                 boolbase.falseFunc,


### PR DESCRIPTION
## Problem

The `~=` (whitespace-separated "one of") attribute handler only short-circuits to `boolbase.falseFunc` when the value *contains* whitespace. An **empty** value falls through to the regex `(?:^|\s)(?:$|\s)`, which matches an empty attribute — so `[class~=""]` wrongly selects elements with `class=""`.

```js
import * as CSSselect from "css-select";
import { parseDocument } from "htmlparser2";

const dom = parseDocument(`<i class=""></i>`);
CSSselect.selectAll('[class~=""]', dom); // ← returns the <i>, should be []
```

## Expected behaviour

Per [Selectors §6.3.2](https://www.w3.org/TR/selectors-4/#attribute-representation), an empty (or whitespace-containing) `~=` value can never be a single token, so it represents nothing. Browsers agree — `document.querySelectorAll('[class~=""]')` returns nothing in Chrome.

This also makes `~=` consistent with `^=` / `$=` / `*=` (`start` / `end` / `any`), which already short-circuit empty values to `falseFunc`.

## Change

Add `value === ""` to the existing short-circuit in the `element` (`~=`) handler, plus a test mirroring the existing empty-value tests for `$=` / `*=`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed attribute selector matching to properly handle empty string values as non-matching cases.

* **Tests**
  * Added test coverage for attribute selectors with empty string values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->