### PR TITLE
chore: use HTTPS repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     ],
     "repository": {
         "type": "git",
-        "url": "git://github.com/fb55/css-select.git"
+        "url": "https://github.com/fb55/css-select.git"
     },
     "sideEffects": false,
     "type": "module",


### PR DESCRIPTION
Updates the package repository metadata to use HTTPS instead of the unauthenticated `git://` protocol.

Validation:
- `git diff --check`
- parsed the changed `package.json` file(s) with Node.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration in package metadata for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->